### PR TITLE
fix: prevent stdout contamination in MCP server mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -175,7 +175,7 @@ async function main() {
     
     if (isDashboardMode) {
       // Dashboard only mode
-      console.log(`Starting Spec Workflow Dashboard for project: ${projectPath}`);
+      console.error(`Starting Spec Workflow Dashboard for project: ${projectPath}`);
       if (port) {
         console.log(`Using custom port: ${port}`);
       }
@@ -205,8 +205,8 @@ async function main() {
       
     } else {
       // MCP server mode (with optional auto-start dashboard)
-      console.log(`Starting Spec Workflow MCP Server for project: ${projectPath}`);
-      console.log(`Working directory: ${process.cwd()}`);
+      console.error(`Starting Spec Workflow MCP Server for project: ${projectPath}`);
+      console.error(`Working directory: ${process.cwd()}`);
       
       const server = new SpecWorkflowMCPServer();
       
@@ -223,7 +223,7 @@ async function main() {
       
       // Inform user about MCP server lifecycle
       if (autoStartDashboard) {
-        console.log('\nMCP server is running. The server and dashboard will shut down when the MCP client disconnects.');
+        console.error('\nMCP server is running. The server and dashboard will shut down when the MCP client disconnects.');
       }
       
       // Handle graceful shutdown

--- a/src/server.ts
+++ b/src/server.ts
@@ -81,7 +81,7 @@ export class SpecWorkflowMCPServer {
         await this.sessionManager.createSession(this.dashboardUrl);
         
         // Log dashboard startup info
-        console.log(`Dashboard auto-started at: ${this.dashboardUrl}`);
+        console.error(`Dashboard auto-started at: ${this.dashboardUrl}`);
       }
       
       // Create context for tools


### PR DESCRIPTION
Replaces console.log with console.error for diagnostic messages to avoid JSON parsing errors in MCP clients. Stdout must be reserved exclusively for JSON-RPC protocol communication.

Fixes #71

Generated with [Claude Code](https://claude.ai/code)