### PR TITLE
feat: Implement document management and prompt editor UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pimzino/spec-workflow-mcp",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pimzino/spec-workflow-mcp",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "license": "GPL-3.0",
       "dependencies": {
         "@fastify/static": "^7.0.4",

--- a/src/dashboard_frontend/src/modules/api/api.tsx
+++ b/src/dashboard_frontend/src/modules/api/api.tsx
@@ -61,6 +61,10 @@ type ApiContextType = {
   unarchiveSpec: (name: string) => Promise<{ ok: boolean; status: number }>;
   getSteeringDocument: (name: string) => Promise<{ content: string; lastModified: string }>;
   saveSteeringDocument: (name: string, content: string) => Promise<{ ok: boolean; status: number }>;
+  listCustomDocuments: () => Promise<string[]>;
+  getCustomDocument: (path: string) => Promise<{ content: string; lastModified: string | null }>;
+  saveCustomDocument: (path: string, content: string) => Promise<{ ok: boolean; status: number }>;
+  saveTaskPrompt: (specName: string, taskId: string, prompt: string) => Promise<{ ok: boolean; status: number }>;
 };
 
 const ApiContext = createContext<ApiContextType | undefined>(undefined);
@@ -149,6 +153,10 @@ export function ApiProvider({ initial, children }: { initial?: { specs?: SpecSum
     unarchiveSpec: (name: string) => postJson(`/api/specs/${encodeURIComponent(name)}/unarchive`, {}),
     getSteeringDocument: (name: string) => getJson(`/api/steering/${encodeURIComponent(name)}`),
     saveSteeringDocument: (name: string, content: string) => putJson(`/api/steering/${encodeURIComponent(name)}`, { content }),
+    listCustomDocuments: () => getJson('/api/documents'),
+    getCustomDocument: (path: string) => getJson(`/api/documents/${path}`),
+    saveCustomDocument: (path: string, content: string) => postJson(`/api/documents/${path}`, { content }),
+    saveTaskPrompt: (specName: string, taskId: string, prompt: string) => postJson(`/api/specs/${encodeURIComponent(specName)}/tasks/${encodeURIComponent(taskId)}/prompt`, { prompt }),
   }), [specs, archivedSpecs, approvals, info, steeringDocuments, reloadAll]);
 
   return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>;

--- a/src/dashboard_frontend/src/modules/app/App.tsx
+++ b/src/dashboard_frontend/src/modules/app/App.tsx
@@ -11,6 +11,7 @@ import { SteeringPage } from '../pages/SteeringPage';
 import { TasksPage } from '../pages/TasksPage';
 import { ApprovalsPage } from '../pages/ApprovalsPage';
 import { SpecViewerPage } from '../pages/SpecViewerPage';
+import { ProjectDocumentsPage } from '../pages/ProjectDocumentsPage';
 import { NotificationProvider, useNotifications } from '../notifications/NotificationProvider';
 import { VolumeControl } from '../notifications/VolumeControl';
 import { useApi } from '../api/api';
@@ -60,6 +61,9 @@ function Header() {
               </NavLink>
               <NavLink to="/steering" className={({ isActive }) => `px-3 py-1.5 rounded-lg ${isActive ? 'bg-indigo-600 text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}>
                 {t('nav.steering')}
+              </NavLink>
+              <NavLink to="/documents" className={({ isActive }) => `px-3 py-1.5 rounded-lg ${isActive ? 'bg-indigo-600 text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}>
+                {t('nav.documents', 'Documents')}
               </NavLink>
               <NavLink to="/specs" className={({ isActive }) => `px-3 py-1.5 rounded-lg ${isActive ? 'bg-indigo-600 text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}>
                 {t('nav.specs')}
@@ -164,6 +168,17 @@ function Header() {
                   </svg>
                   {t('nav.steering')}
                 </NavLink>
+
+                <NavLink
+                  to="/documents"
+                  onClick={closeMobileMenu}
+                  className={({ isActive }) => `flex items-center px-3 py-2 rounded-lg text-base font-medium transition-colors ${isActive ? 'bg-indigo-600 text-white' : 'text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'}`}
+                >
+                  <svg className="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-5l-2-2H5a2 2 0 00-2 2z" />
+                  </svg>
+                  {t('nav.documents', 'Documents')}
+                </NavLink>
                 
                 <NavLink 
                   to="/specs" 
@@ -262,6 +277,7 @@ function AppInner() {
             <Routes>
               <Route path="/" element={<DashboardStatistics />} />
               <Route path="/steering" element={<SteeringPage />} />
+              <Route path="/documents" element={<ProjectDocumentsPage />} />
               <Route path="/specs" element={<SpecsPage />} />
               <Route path="/specs/view" element={<SpecViewerPage />} />
               <Route path="/tasks" element={<TasksPage />} />

--- a/src/dashboard_frontend/src/modules/editor/DocumentEditorModal.tsx
+++ b/src/dashboard_frontend/src/modules/editor/DocumentEditorModal.tsx
@@ -15,7 +15,6 @@ export type Document = {
 export function DocumentEditorModal({ document, isOpen, onClose }: { document: Document | null; isOpen: boolean; onClose: (shouldReload: boolean) => void }) {
   const { getCustomDocument, saveCustomDocument } = useApi();
   const { t } = useTranslation();
-  const [viewMode, setViewMode] = useState<'rendered' | 'source' | 'editor'>('rendered');
   const [content, setContent] = useState<string>('');
   const [editContent, setEditContent] = useState<string>('');
   const [loading, setLoading] = useState<boolean>(false);
@@ -91,12 +90,12 @@ export function DocumentEditorModal({ document, isOpen, onClose }: { document: D
   }, [document, editContent, saveCustomDocument]);
 
   const handleClose = useCallback(() => {
-    if (hasUnsavedChanges && viewMode === 'editor') {
+    if (hasUnsavedChanges) {
       setConfirmCloseModalOpen(true);
       return;
     }
     onClose(hasUnsavedChanges);
-  }, [hasUnsavedChanges, viewMode, onClose]);
+  }, [hasUnsavedChanges, onClose]);
 
   const handleConfirmClose = () => {
     onClose(false); // Don't reload if they discard changes
@@ -104,60 +103,9 @@ export function DocumentEditorModal({ document, isOpen, onClose }: { document: D
 
   if (!isOpen || !document) return null;
 
-  const renderContent = () => {
-    if (loading) {
-      return (
-        <div className="flex items-center justify-center py-12">
-          <svg className="animate-spin h-6 w-6 text-gray-500" fill="none" viewBox="0 0 24 24">
-            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-          </svg>
-          <span className="ml-2">{t('common.loadingContent')}</span>
-        </div>
-      );
-    }
-
-    if (!content && viewMode !== 'editor') {
-      return (
-        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
-          <p>{t('common.noContentAvailable')}</p>
-          <button onClick={() => setViewMode('editor')} className="mt-4 btn-primary">
-            {t('documents.createNow', 'Create Now')}
-          </button>
-        </div>
-      );
-    }
-
-    if (viewMode === 'rendered') {
-      return <Markdown content={content} />;
-    } else if (viewMode === 'source') {
-      return (
-        <div className="bg-gray-50 dark:bg-gray-900 p-3 sm:p-4 rounded-lg text-xs sm:text-sm overflow-auto">
-          <pre className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed overflow-x-auto">
-            {content}
-          </pre>
-        </div>
-      );
-    } else {
-      return (
-        <div className="h-full">
-          <MarkdownEditor
-            content={content}
-            editContent={editContent}
-            onChange={setEditContent}
-            onSave={handleSave}
-            saving={saving}
-            saved={saved}
-            error={saveError}
-          />
-        </div>
-      );
-    }
-  };
-
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">
-      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-7xl overflow-hidden flex flex-col h-[95vh]`}>
+      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-[95vw] overflow-hidden flex flex-col h-[95vh]`}>
         <div className="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700">
           <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white truncate">
             {t('documentEditor.title', { name: document.name })}
@@ -173,22 +121,38 @@ export function DocumentEditorModal({ document, isOpen, onClose }: { document: D
           </button>
         </div>
 
-        <div className="flex items-center justify-end p-3 sm:p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 gap-3 sm:gap-4">
-          <div className="flex items-center bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600">
-            <button onClick={() => setViewMode('rendered')} className={`px-3 py-1.5 text-sm rounded-l-lg transition-colors ${viewMode === 'rendered' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
-              {t('common.viewMode.rendered')}
-            </button>
-            <button onClick={() => setViewMode('source')} className={`px-3 py-1.5 text-sm transition-colors ${viewMode === 'source' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
-              {t('common.viewMode.source')}
-            </button>
-            <button onClick={() => setViewMode('editor')} className={`px-3 py-1.5 text-sm rounded-r-lg transition-colors ${viewMode === 'editor' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
-              {t('common.viewMode.editor')}
-            </button>
+        <div className="flex-1 grid grid-cols-1 md:grid-cols-2 gap-px bg-gray-200 dark:bg-gray-700 overflow-hidden">
+          {/* Editor Pane */}
+          <div className="flex flex-col bg-white dark:bg-gray-800">
+            <MarkdownEditor
+              content={content}
+              editContent={editContent}
+              onChange={setEditContent}
+              onSave={handleSave}
+              saving={saving}
+              saved={saved}
+              error={saveError}
+            />
           </div>
-        </div>
 
-        <div className={`${viewMode === 'editor' ? 'flex-1 overflow-hidden' : 'flex-1 p-3 sm:p-6 overflow-auto min-h-0'}`}>
-          {renderContent()}
+          {/* Preview Pane */}
+          <div className="hidden md:flex flex-col bg-white dark:bg-gray-900">
+             <div className="p-4 border-b border-gray-200 dark:border-gray-700">
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300">{t('common.preview', 'Preview')}</h3>
+            </div>
+            <div className="p-6 overflow-auto flex-1">
+              {loading ? (
+                 <div className="flex items-center justify-center h-full">
+                   <svg className="animate-spin h-6 w-6 text-gray-500" fill="none" viewBox="0 0 24 24">
+                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                     <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                   </svg>
+                 </div>
+              ) : (
+                <Markdown content={editContent} />
+              )}
+            </div>
+          </div>
         </div>
       </div>
 

--- a/src/dashboard_frontend/src/modules/editor/DocumentEditorModal.tsx
+++ b/src/dashboard_frontend/src/modules/editor/DocumentEditorModal.tsx
@@ -1,0 +1,207 @@
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { useApi } from '../api/api';
+import { Markdown } from '../markdown/Markdown';
+import { MarkdownEditor } from './MarkdownEditor';
+import { ConfirmationModal } from '../modals/ConfirmationModal';
+import { useTranslation } from 'react-i18next';
+
+export type Document = {
+  path: string;
+  name: string;
+  lastModified?: string;
+  content?: string;
+};
+
+export function DocumentEditorModal({ document, isOpen, onClose }: { document: Document | null; isOpen: boolean; onClose: (shouldReload: boolean) => void }) {
+  const { getCustomDocument, saveCustomDocument } = useApi();
+  const { t } = useTranslation();
+  const [viewMode, setViewMode] = useState<'rendered' | 'source' | 'editor'>('rendered');
+  const [content, setContent] = useState<string>('');
+  const [editContent, setEditContent] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(false);
+  const [saving, setSaving] = useState<boolean>(false);
+  const [saved, setSaved] = useState<boolean>(false);
+  const [saveError, setSaveError] = useState<string>('');
+  const [confirmCloseModalOpen, setConfirmCloseModalOpen] = useState<boolean>(false);
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+
+  useEffect(() => {
+    setHasUnsavedChanges(editContent !== content);
+  }, [editContent, content]);
+
+  // Load document when modal opens
+  useEffect(() => {
+    if (!isOpen || !document) {
+      setContent('');
+      setEditContent('');
+      return;
+    }
+
+    let active = true;
+    setLoading(true);
+
+    getCustomDocument(document.path)
+      .then((data) => {
+        if (active) {
+          const documentContent = data.content || '';
+          setContent(documentContent);
+          setEditContent(documentContent);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setContent('');
+          setEditContent('');
+        }
+      })
+      .finally(() => {
+        if (active) {
+          setLoading(false);
+        }
+      });
+
+    return () => { active = false; };
+  }, [isOpen, document, getCustomDocument]);
+
+  useEffect(() => {
+    setSaved(false);
+    setSaveError('');
+  }, [document]);
+
+  const handleSave = useCallback(async () => {
+    if (!document) return;
+
+    setSaving(true);
+    setSaveError('');
+
+    try {
+      const result = await saveCustomDocument(document.path, editContent);
+      if (result.ok) {
+        setSaved(true);
+        setContent(editContent);
+        setTimeout(() => setSaved(false), 3000);
+      } else {
+        setSaveError('Failed to save document');
+      }
+    } catch (error: any) {
+      setSaveError(error.message || 'Failed to save document');
+    } finally {
+      setSaving(false);
+    }
+  }, [document, editContent, saveCustomDocument]);
+
+  const handleClose = useCallback(() => {
+    if (hasUnsavedChanges && viewMode === 'editor') {
+      setConfirmCloseModalOpen(true);
+      return;
+    }
+    onClose(hasUnsavedChanges);
+  }, [hasUnsavedChanges, viewMode, onClose]);
+
+  const handleConfirmClose = () => {
+    onClose(false); // Don't reload if they discard changes
+  };
+
+  if (!isOpen || !document) return null;
+
+  const renderContent = () => {
+    if (loading) {
+      return (
+        <div className="flex items-center justify-center py-12">
+          <svg className="animate-spin h-6 w-6 text-gray-500" fill="none" viewBox="0 0 24 24">
+            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+          </svg>
+          <span className="ml-2">{t('common.loadingContent')}</span>
+        </div>
+      );
+    }
+
+    if (!content && viewMode !== 'editor') {
+      return (
+        <div className="text-center py-12 text-gray-500 dark:text-gray-400">
+          <p>{t('common.noContentAvailable')}</p>
+          <button onClick={() => setViewMode('editor')} className="mt-4 btn-primary">
+            {t('documents.createNow', 'Create Now')}
+          </button>
+        </div>
+      );
+    }
+
+    if (viewMode === 'rendered') {
+      return <Markdown content={content} />;
+    } else if (viewMode === 'source') {
+      return (
+        <div className="bg-gray-50 dark:bg-gray-900 p-3 sm:p-4 rounded-lg text-xs sm:text-sm overflow-auto">
+          <pre className="whitespace-pre-wrap text-gray-800 dark:text-gray-200 leading-relaxed overflow-x-auto">
+            {content}
+          </pre>
+        </div>
+      );
+    } else {
+      return (
+        <div className="h-full">
+          <MarkdownEditor
+            content={content}
+            editContent={editContent}
+            onChange={setEditContent}
+            onSave={handleSave}
+            saving={saving}
+            saved={saved}
+            error={saveError}
+          />
+        </div>
+      );
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-2 sm:p-4">
+      <div className={`bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-7xl overflow-hidden flex flex-col h-[95vh]`}>
+        <div className="flex items-center justify-between p-4 sm:p-6 border-b border-gray-200 dark:border-gray-700">
+          <h2 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-white truncate">
+            {t('documentEditor.title', { name: document.name })}
+          </h2>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors p-2 -m-2 ml-4"
+            aria-label={t('common.close')}
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex items-center justify-end p-3 sm:p-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 gap-3 sm:gap-4">
+          <div className="flex items-center bg-white dark:bg-gray-800 rounded-lg border border-gray-300 dark:border-gray-600">
+            <button onClick={() => setViewMode('rendered')} className={`px-3 py-1.5 text-sm rounded-l-lg transition-colors ${viewMode === 'rendered' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
+              {t('common.viewMode.rendered')}
+            </button>
+            <button onClick={() => setViewMode('source')} className={`px-3 py-1.5 text-sm transition-colors ${viewMode === 'source' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
+              {t('common.viewMode.source')}
+            </button>
+            <button onClick={() => setViewMode('editor')} className={`px-3 py-1.5 text-sm rounded-r-lg transition-colors ${viewMode === 'editor' ? 'bg-blue-600 text-white' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'}`}>
+              {t('common.viewMode.editor')}
+            </button>
+          </div>
+        </div>
+
+        <div className={`${viewMode === 'editor' ? 'flex-1 overflow-hidden' : 'flex-1 p-3 sm:p-6 overflow-auto min-h-0'}`}>
+          {renderContent()}
+        </div>
+      </div>
+
+      <ConfirmationModal
+        isOpen={confirmCloseModalOpen}
+        onClose={() => setConfirmCloseModalOpen(false)}
+        onConfirm={handleConfirmClose}
+        title={t('common.unsavedChanges.title')}
+        message={t('common.unsavedChanges.message')}
+        confirmText={t('common.close')}
+        cancelText={t('common.keepEditing')}
+        variant="danger"
+      />
+    </div>
+  );
+}

--- a/src/dashboard_frontend/src/modules/markdown/Markdown.tsx
+++ b/src/dashboard_frontend/src/modules/markdown/Markdown.tsx
@@ -14,8 +14,9 @@ function createMd(): MarkdownIt {
     typographer: true,
     highlight(str, lang) {
       if (lang === 'mermaid') {
+        const key = `mermaid-${Date.now()}-${Math.random()}`;
         // Render as mermaid container; actual rendering happens in useEffect
-        return `<div class="mermaid">${str}</div>`;
+        return `<div class="mermaid" key="${key}">${str}</div>`;
       }
       if (lang && hljs.getLanguage(lang)) {
         try {
@@ -35,7 +36,8 @@ function createMd(): MarkdownIt {
     const token = tokens[idx];
     const langInfo = token.info ? token.info.trim() : '';
     if (langInfo === 'mermaid') {
-      return `<div class="mermaid">${token.content}</div>`;
+      const key = `mermaid-fence-${Date.now()}-${Math.random()}`;
+      return `<div class="mermaid" key="${key}">${token.content}</div>`;
     }
     return fence ? fence(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
   };

--- a/src/dashboard_frontend/src/modules/modals/PromptEditorModal.tsx
+++ b/src/dashboard_frontend/src/modules/modals/PromptEditorModal.tsx
@@ -1,0 +1,110 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface PromptEditorModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (text: string) => void;
+  onCopy: (text: string) => void;
+  title: string;
+  initialValue?: string;
+  saveText?: string;
+  copyText?: string;
+  closeText?: string;
+}
+
+export function PromptEditorModal({
+  isOpen,
+  onClose,
+  onSave,
+  onCopy,
+  title,
+  initialValue = '',
+  saveText = 'Save',
+  copyText = 'Copy',
+  closeText = 'Close',
+}: PromptEditorModalProps) {
+  const { t } = useTranslation();
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (isOpen) {
+      setValue(initialValue);
+    }
+  }, [isOpen, initialValue]);
+
+  const handleSave = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSave(value);
+  };
+
+  const handleCopy = () => {
+    onCopy(value);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl">
+        <form onSubmit={handleSave}>
+          <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+              {title}
+            </h3>
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+              aria-label={t('common.closeModalAria')}
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="p-6">
+            <textarea
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 resize-vertical min-h-[200px]"
+              rows={8}
+              autoFocus
+            />
+          </div>
+
+          <div className="flex items-center justify-end gap-3 p-6 border-t border-gray-200 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+            >
+              {closeText}
+            </button>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-4 py-2 text-sm font-medium text-white bg-green-600 border border-transparent rounded-md hover:bg-green-700 focus:ring-2 focus:ring-green-500 focus:ring-offset-2 transition-colors"
+            >
+              {copyText}
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors"
+            >
+              {saveText}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/dashboard_frontend/src/modules/pages/ProjectDocumentsPage.tsx
+++ b/src/dashboard_frontend/src/modules/pages/ProjectDocumentsPage.tsx
@@ -1,0 +1,185 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { DocumentEditorModal, Document } from '../editor/DocumentEditorModal';
+import { useApi } from '../api/api';
+
+const documentStructure = [
+  {
+    category: '要件定義',
+    categoryKey: 'requirementDefinition',
+    documents: [
+      { name: 'プロジェクト概要', nameKey: 'projectOverview' },
+      { name: '現行フロー', nameKey: 'currentFlow' },
+      { name: '業務要件一覧', nameKey: 'businessRequirements' },
+      { name: 'システム化フロー', nameKey: 'systematizationFlow' },
+      { name: '機能要件一覧', nameKey: 'functionalRequirements' },
+      { name: '非機能要件一覧', nameKey: 'nonFunctionalRequirements' },
+    ],
+  },
+  {
+    category: '基本設計',
+    categoryKey: 'basicDesign',
+    documents: [
+      { name: 'システム設計', nameKey: 'systemDesign' },
+      { name: 'システム概要', nameKey: 'systemOverview' },
+      { name: 'テーブル定義', nameKey: 'tableDefinition' },
+      { name: 'ER図', nameKey: 'erDiagram' },
+      { name: '画面遷移', nameKey: 'screenTransition' },
+      { name: '画面一覧', nameKey: 'screenList' },
+      { name: '画面UI', nameKey: 'screenUi' },
+    ],
+  },
+  {
+    category: '詳細設計',
+    categoryKey: 'detailedDesign',
+    documents: [
+      { name: '共通コンポーネント', nameKey: 'commonComponents' },
+      { name: 'バックエンド処理', nameKey: 'backendProcessing' },
+      { name: 'API仕様書', nameKey: 'apiSpecification' },
+      { name: 'シーケンス図', nameKey: 'sequenceDiagram' },
+      { name: 'アーキテクチャ', nameKey: 'architecture' },
+    ],
+  },
+  {
+    category: 'テスト',
+    categoryKey: 'test',
+    documents: [
+      { name: '結合テスト', nameKey: 'integrationTest' },
+      { name: 'システムテスト', nameKey: 'systemTest' },
+    ],
+  },
+];
+
+function DocumentItem({ doc, categoryKey, onOpenModal, exists }: { doc: { name: string; nameKey: string }; categoryKey: string; onOpenModal: (doc: Document) => void; exists: boolean }) {
+  const { t } = useTranslation();
+  const { name, nameKey } = doc;
+
+  const handleClick = () => {
+    onOpenModal({
+      path: `${categoryKey}/${nameKey}.md`,
+      name: t(`documents.${nameKey}`, name),
+    });
+  };
+
+  return (
+    <div
+      className="flex items-center justify-between p-3 pl-10 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer rounded-md"
+      onClick={handleClick}
+    >
+      <div className="flex items-center">
+        <svg className="w-4 h-4 mr-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+        </svg>
+        <span>{t(`documents.${nameKey}`, name)}</span>
+      </div>
+      <span className={`px-2 py-1 text-xs rounded-full ${exists ? 'bg-green-100 text-green-800 dark:bg-green-900/20 dark:text-green-400' : 'bg-gray-100 text-gray-800 dark:bg-gray-900/20 dark:text-gray-400'}`}>
+        {exists ? t('documents.status.created', 'Created') : t('documents.status.notCreated', 'Not Created')}
+      </span>
+    </div>
+  );
+}
+
+function DocumentCategory({ category, categoryKey, documents, onOpenModal, existingDocs }: { category: string; categoryKey: string; documents: { name: string; nameKey: string }[]; onOpenModal: (doc: Document) => void; existingDocs: string[] }) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4">
+      <div
+        className="flex items-center justify-between cursor-pointer"
+        onClick={() => setIsOpen(!isOpen)}
+      >
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          {t(`documents.categories.${categoryKey}`, category)}
+        </h2>
+        <svg
+          className={`w-5 h-5 text-gray-500 dark:text-gray-400 transition-transform ${
+            isOpen ? 'transform rotate-180' : ''
+          }`}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7" />
+        </svg>
+      </div>
+      {isOpen && (
+        <div className="mt-4 space-y-2">
+          {documents.map((doc) => (
+            <DocumentItem
+              key={doc.nameKey}
+              doc={doc}
+              categoryKey={categoryKey}
+              onOpenModal={onOpenModal}
+              exists={existingDocs.includes(`${categoryKey}/${doc.nameKey}.md`)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ProjectDocumentsPage() {
+  const { t } = useTranslation();
+  const [selectedDocument, setSelectedDocument] = useState<Document | null>(null);
+  const { listCustomDocuments } = useApi();
+  const [existingDocs, setExistingDocs] = useState<string[]>([]);
+
+  const fetchExistingDocs = useCallback(async () => {
+    try {
+      const docs = await listCustomDocuments();
+      setExistingDocs(docs.map(d => d.replace(/\\/g, '/')));
+    } catch (error) {
+      console.error("Failed to fetch custom documents:", error);
+    }
+  }, [listCustomDocuments]);
+
+
+  useEffect(() => {
+    fetchExistingDocs();
+  }, [fetchExistingDocs]);
+
+  const handleOpenModal = (doc: Document) => {
+    setSelectedDocument(doc);
+  };
+
+  const handleCloseModal = (shouldReload: boolean) => {
+    setSelectedDocument(null);
+    if (shouldReload) {
+      fetchExistingDocs();
+    }
+  };
+
+  return (
+    <div className="grid gap-6">
+       <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-4 sm:p-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex-1 min-w-0">
+            <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+              {t('nav.documents', 'Project Documents')}
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {t('documents.subtitle', 'Create and manage project-specific documents from the UI.')}
+            </p>
+          </div>
+        </div>
+      </div>
+      {documentStructure.map((category) => (
+        <DocumentCategory
+          key={category.categoryKey}
+          category={category.category}
+          categoryKey={category.categoryKey}
+          documents={category.documents}
+          onOpenModal={handleOpenModal}
+          existingDocs={existingDocs}
+        />
+      ))}
+      <DocumentEditorModal
+        isOpen={!!selectedDocument}
+        onClose={handleCloseModal}
+        document={selectedDocument}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This commit introduces two major features to enhance the UI/UX of the application:

1.  **Project Document Management:**
    - Adds a new "Documents" page to the web UI.
    - This page displays a hierarchical list of project documents (e.g., Requirement Definition, Basic Design) as specified by the user.
    - Users can now create, view, and edit these documents directly in the UI using a Markdown editor.
    - The documents are stored as Markdown files in the `.spec-workflow/documents/` directory.
    - New backend API endpoints (`/api/documents/*`) have been added to support this functionality.

2.  **Prompt Editor Enhancement:**
    - Replaces the "Copy Prompt" button on the Tasks page with an "Edit Prompt" button.
    - Clicking this button opens a modal where the user can view, edit, save, and copy the AI prompt for a task.
    - This allows users to review and refine prompts before using them.
    - A new backend API endpoint (`/api/specs/:specName/tasks/:taskId/prompt`) has been added to save the updated prompts to the `tasks.md` file.