### PR TITLE
feat: Support for sandboxed MCP clients (Codex CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Useful in restricted Windows environments where firewall or antivirus software blocks browser launches from processes
   - Prevents "failed to start dashboard: spawn EPERM" errors for users without administrator privileges
   - Dashboard URL is still printed to console so users can manually navigate to it
+- **Sandbox Environment Support** (fixes #144) - Added `SPEC_WORKFLOW_HOME` environment variable to support sandboxed MCP clients like Codex CLI:
+  - Allows overriding the default global state directory (`~/.spec-workflow-mcp`) to a writable location
+  - Essential for sandboxed environments where `$HOME` is read-only (e.g., Codex CLI with `sandbox_mode=workspace-write`)
+  - Supports both absolute paths and relative paths (resolved against current working directory)
+  - Added helpful error messages when permission errors occur, suggesting the `SPEC_WORKFLOW_HOME` workaround
+  - Updated Docker configuration to use `SPEC_WORKFLOW_HOME` by default
+  - Usage: `SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx spec-workflow-mcp /workspace`
 
 ### Fixed
 - **Archived Specs Display Content Correctly** (PR #146) - Fixed critical bug where archived specs were not displaying content correctly in the dashboard:

--- a/README.md
+++ b/README.md
@@ -222,6 +222,16 @@ The dashboard will be available at: http://localhost:5000
 
 [See Docker setup guide →](containers/README.md)
 
+## 🔒 Sandboxed Environments
+
+For sandboxed environments (e.g., Codex CLI with `sandbox_mode=workspace-write`) where `$HOME` is read-only, use the `SPEC_WORKFLOW_HOME` environment variable to redirect global state files to a writable location:
+
+```bash
+SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx -y @pimzino/spec-workflow-mcp@latest /workspace
+```
+
+[See Configuration Guide →](docs/CONFIGURATION.md#environment-variables)
+
 ## 📚 Documentation
 
 - [Configuration Guide](docs/CONFIGURATION.md) - Command-line options, config files

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -28,7 +28,7 @@ RUN npm ci --only=production
 # Copy built application
 COPY --from=builder /app/dist ./dist
 
-RUN mkdir -p /workspace
+RUN mkdir -p /workspace /workspace/.spec-workflow-mcp
 
 # Change ownership of the app directory to the node user (uid=1000)
 RUN chown -R node:node /app /workspace
@@ -37,6 +37,9 @@ RUN chown -R node:node /app /workspace
 USER node
 
 WORKDIR /workspace
+
+# Set SPEC_WORKFLOW_HOME to store global state in workspace (required for containerized environments)
+ENV SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp
 
 EXPOSE 5000
 

--- a/containers/docker-compose.yml
+++ b/containers/docker-compose.yml
@@ -7,6 +7,10 @@ services:
       - "${DASHBOARD_PORT:-5000}:${DASHBOARD_PORT:-5000}"
     volumes:
       - "${SPEC_WORKFLOW_PATH:-./workspace}/.spec-workflow:/workspace/.spec-workflow:rw"
+      # Mount global state directory if using SPEC_WORKFLOW_HOME
+      - "${SPEC_WORKFLOW_PATH:-./workspace}/.spec-workflow-mcp:/workspace/.spec-workflow-mcp:rw"
     environment:
       - DASHBOARD_PORT=${DASHBOARD_PORT:-5000}
+      # Store global state files in workspace (required for sandboxed environments)
+      - SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp
     restart: unless-stopped

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -57,9 +57,47 @@ Only use a custom port if port 5000 is unavailable:
 npx -y @pimzino/spec-workflow-mcp@latest --dashboard --port 8080
 ```
 
+## Environment Variables
+
+### SPEC_WORKFLOW_HOME
+
+Override the default global state directory (`~/.spec-workflow-mcp`). This is useful for sandboxed environments where `$HOME` is read-only.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SPEC_WORKFLOW_HOME` | `~/.spec-workflow-mcp` | Directory for global state files |
+
+**Files stored in this directory:**
+- `activeProjects.json` - Project registry
+- `activeSession.json` - Dashboard session info
+- `settings.json` - Global settings
+- `job-execution-history.json` - Job execution history
+- `migration.log` - Implementation log migration tracking
+
+**Usage examples:**
+
+```bash
+# Absolute path
+SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx -y @pimzino/spec-workflow-mcp@latest /workspace
+
+# Relative path (resolved against current working directory)
+SPEC_WORKFLOW_HOME=./.spec-workflow-mcp npx -y @pimzino/spec-workflow-mcp@latest .
+
+# For dashboard mode
+SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx -y @pimzino/spec-workflow-mcp@latest --dashboard
+```
+
+**Sandboxed environments (e.g., Codex CLI):**
+
+When running in sandboxed environments like Codex CLI with `sandbox_mode=workspace-write`, set `SPEC_WORKFLOW_HOME` to a writable location within your workspace:
+
+```bash
+SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx -y @pimzino/spec-workflow-mcp@latest /workspace
+```
+
 ## Dashboard Session Management
 
-The dashboard stores its session information in `~/.spec-workflow-mcp/activeSession.json`. This file:
+The dashboard stores its session information in `~/.spec-workflow-mcp/activeSession.json` (or `$SPEC_WORKFLOW_HOME/activeSession.json` if set). This file:
 - Enforces single dashboard instance
 - Allows MCP servers to discover the running dashboard
 - Automatically cleans up when dashboard stops

--- a/src/core/global-dir.ts
+++ b/src/core/global-dir.ts
@@ -1,0 +1,80 @@
+import { homedir } from 'os';
+import { join, isAbsolute } from 'path';
+
+/**
+ * Environment variable name for overriding the global directory location.
+ * When set, all global state files will be stored in this location instead of ~/.spec-workflow-mcp
+ * 
+ * This is useful for sandboxed environments (e.g., Codex CLI with sandbox_mode=workspace-write)
+ * where $HOME is read-only.
+ * 
+ * @example
+ * // Set to an absolute path
+ * SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx spec-workflow-mcp /workspace
+ * 
+ * // Set to a relative path (resolved against current working directory)
+ * SPEC_WORKFLOW_HOME=./.spec-workflow-mcp npx spec-workflow-mcp /workspace
+ */
+export const SPEC_WORKFLOW_HOME_ENV = 'SPEC_WORKFLOW_HOME';
+
+const DEFAULT_DIR_NAME = '.spec-workflow-mcp';
+
+/**
+ * Get the global directory path for storing spec-workflow-mcp state files.
+ * 
+ * Resolution order:
+ * 1. SPEC_WORKFLOW_HOME environment variable (if set)
+ *    - Absolute paths are used as-is
+ *    - Relative paths are resolved against process.cwd()
+ * 2. Default: ~/.spec-workflow-mcp
+ * 
+ * Files stored in this directory:
+ * - activeProjects.json - Project registry
+ * - activeSession.json - Dashboard session info
+ * - settings.json - Global settings
+ * - job-execution-history.json - Job execution history
+ * - migration.log - Implementation log migration tracking
+ * 
+ * @returns The absolute path to the global directory
+ */
+export function getGlobalDir(): string {
+  const envPath = process.env[SPEC_WORKFLOW_HOME_ENV];
+  
+  if (envPath) {
+    // If an environment variable is set, use it
+    // Handle both absolute and relative paths
+    return isAbsolute(envPath) ? envPath : join(process.cwd(), envPath);
+  }
+  
+  // Default to ~/.spec-workflow-mcp
+  return join(homedir(), DEFAULT_DIR_NAME);
+}
+
+/**
+ * Get a helpful error message for permission errors when accessing the global directory.
+ * Suggests using SPEC_WORKFLOW_HOME environment variable.
+ * 
+ * @param operation - The operation that failed (e.g., "create directory", "write file")
+ * @param path - The path that couldn't be accessed
+ * @returns A formatted error message with suggestions
+ */
+export function getPermissionErrorHelp(operation: string, path: string): string {
+  return `
+Failed to ${operation}: ${path}
+
+This error typically occurs in sandboxed environments where $HOME is read-only.
+
+To fix this, set the SPEC_WORKFLOW_HOME environment variable to a writable location:
+
+  SPEC_WORKFLOW_HOME=/path/to/writable/dir npx spec-workflow-mcp [project-path]
+
+For example, to store state files in your workspace:
+
+  SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx spec-workflow-mcp /workspace
+
+Or use a relative path:
+
+  SPEC_WORKFLOW_HOME=./.spec-workflow-mcp npx spec-workflow-mcp .
+`.trim();
+}
+

--- a/src/core/workspace-initializer.ts
+++ b/src/core/workspace-initializer.ts
@@ -1,9 +1,9 @@
 import { promises as fs } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { homedir } from 'os';
 import { PathUtils } from './path-utils.js';
 import { ImplementationLogMigrator } from './implementation-log-migrator.js';
+import { getGlobalDir } from './global-dir.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -167,7 +167,7 @@ Templates can include placeholders that will be replaced when documents are crea
    */
   private async migrateImplementationLogs(): Promise<void> {
     try {
-      const userDataDir = resolve(homedir(), '.spec-workflow-mcp');
+      const userDataDir = getGlobalDir();
       const specsDir = join(PathUtils.getWorkflowRoot(this.projectPath), 'specs');
 
       // Create user data directory if it doesn't exist


### PR DESCRIPTION
## Summary

Fixes #144

This PR adds support for sandboxed MCP clients like Codex CLI by introducing the \SPEC_WORKFLOW_HOME\ environment variable, which allows overriding the default global state directory (\~/.spec-workflow-mcp\).

## Problem

spec-workflow-mcp stores global state files in \\C:\Users\Jose.Freitas/.spec-workflow-mcp/\:
- \ctiveProjects.json\ - Project registry
- \ctiveSession.json\ - Dashboard session info
- \settings.json\ - Global settings
- \job-execution-history.json\ - Job execution history
- \migration.log\ - Implementation log migration tracking

In sandboxed environments like Codex CLI with \sandbox_mode=workspace-write\, \\C:\Users\Jose.Freitas\ is read-only, causing the MCP server to crash with \EACCES: permission denied\ errors.

## Solution

Introduced the \SPEC_WORKFLOW_HOME\ environment variable that allows users to specify an alternative location for global state files:

\\\ash
# Absolute path
SPEC_WORKFLOW_HOME=/workspace/.spec-workflow-mcp npx spec-workflow-mcp /workspace

# Relative path (resolved against cwd)
SPEC_WORKFLOW_HOME=./.spec-workflow-mcp npx spec-workflow-mcp .
\\\

## Changes

### New Files
- \src/core/global-dir.ts\ - Centralized global directory resolver with \getGlobalDir()\ and \getPermissionErrorHelp()\ functions

### Modified Files
- \src/core/project-registry.ts\ - Use \getGlobalDir()\ instead of hardcoded \homedir()\
- \src/core/dashboard-session.ts\ - Use \getGlobalDir()\ instead of hardcoded \homedir()\
- \src/core/workspace-initializer.ts\ - Use \getGlobalDir()\ instead of hardcoded \homedir()\
- \src/dashboard/settings-manager.ts\ - Use \getGlobalDir()\ instead of hardcoded \homedir()\
- \src/dashboard/execution-history-manager.ts\ - Use \getGlobalDir()\ instead of hardcoded \homedir()\
- \containers/Dockerfile\ - Set \SPEC_WORKFLOW_HOME\ by default for containerized environments
- \containers/docker-compose.yml\ - Add \SPEC_WORKFLOW_HOME\ configuration
- \README.md\ - Document sandboxed environment support
- \docs/CONFIGURATION.md\ - Document \SPEC_WORKFLOW_HOME\ environment variable
- \CHANGELOG.md\ - Add entry for version 2.0.10

## Testing

- [x] Build passes (\
pm run build\)
- [x] No linting errors
- [x] Manual testing with \SPEC_WORKFLOW_HOME\ unset (default behavior)
- [x] Manual testing with \SPEC_WORKFLOW_HOME\ set to absolute path
- [x] Manual testing with \SPEC_WORKFLOW_HOME\ set to relative path