### PR TITLE
feat: add path translation utilities for Docker multi-project support

### DIFF
--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -4,6 +4,39 @@ import { constants } from 'fs';
 
 export class PathUtils {
   /**
+   * Translate a host path to container path if running in Docker with path mapping configured.
+   * 
+   * Environment variables:
+   * - SPEC_WORKFLOW_HOST_PATH_PREFIX: Path prefix on the host (e.g., /Users/username)
+   * - SPEC_WORKFLOW_CONTAINER_PATH_PREFIX: Corresponding path in container (e.g., /projects)
+   * 
+   * Example: If host prefix is "/Users/dev" and container prefix is "/projects",
+   * then "/Users/dev/myapp" becomes "/projects/myapp"
+   */
+  static translatePath(hostPath: string): string {
+    const hostPrefix = process.env.SPEC_WORKFLOW_HOST_PATH_PREFIX;
+    const containerPrefix = process.env.SPEC_WORKFLOW_CONTAINER_PATH_PREFIX;
+    
+    if (hostPrefix && containerPrefix && hostPath.startsWith(hostPrefix)) {
+      return hostPath.replace(hostPrefix, containerPrefix);
+    }
+    return hostPath;
+  }
+
+  /**
+   * Reverse translation: container path back to host path (for display/registry)
+   */
+  static reverseTranslatePath(containerPath: string): string {
+    const hostPrefix = process.env.SPEC_WORKFLOW_HOST_PATH_PREFIX;
+    const containerPrefix = process.env.SPEC_WORKFLOW_CONTAINER_PATH_PREFIX;
+    
+    if (hostPrefix && containerPrefix && containerPath.startsWith(containerPrefix)) {
+      return containerPath.replace(containerPrefix, hostPrefix);
+    }
+    return containerPath;
+  }
+
+  /**
    * Safely join paths ensuring no directory traversal
    */
   private static safeJoin(basePath: string, ...paths: string[]): string {


### PR DESCRIPTION
## Summary

Add path translation utilities to `PathUtils` class for Docker multi-project deployments.

**New methods:**
- `translatePath(hostPath)` - Convert host path to container path
- `reverseTranslatePath(containerPath)` - Convert container path back to host path

**Environment variables:**
- `SPEC_WORKFLOW_HOST_PATH_PREFIX` - Path prefix on host (e.g., `/Users/dev`)
- `SPEC_WORKFLOW_CONTAINER_PATH_PREFIX` - Corresponding container path (e.g., `/projects`)

## Problem

When running the dashboard in Docker with host MCP clients (Claude Code, Cursor, etc.):
1. Host client registers project with host path: `/Users/dev/myproject`
2. Dashboard container cannot access `/Users/dev/myproject` - path doesn't exist
3. Container has project files mounted at `/projects/myproject`

## Solution

Path translation maps host paths to container paths at runtime, allowing the dashboard to access files through Docker volume mounts while preserving host paths for display and registry.

## Relationship to SPEC_WORKFLOW_HOME

This complements #144 (SPEC_WORKFLOW_HOME for global state files). Together they provide full Docker isolation:
- **SPEC_WORKFLOW_HOME**: Where to store state files (activeProjects.json, session, etc.)
- **Path translation**: How to access project files registered by host clients

## Test plan

- [ ] Unit tests for `translatePath()` and `reverseTranslatePath()`
- [ ] Verify no-op when env vars not set (backwards compatible)
- [ ] Integration test with Docker deployment
