### PR TITLE
fix: Improve diff visibility in Changes tab (#158)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.1.0] - 2025-12-03
 
+### Fixed
+- **Improved Diff Visibility in Changes Tab** (fixes #158) - Fixed issue where adding a single line would cause all subsequent text to appear as changed:
+  - Replaced naive index-based line comparison with proper `diffLines` algorithm from the `diff` library
+  - Now correctly identifies only the actual changed lines, not positional differences
+  - Provides accurate visual diff representation matching user expectations
+
 ### Added
 - **MDX Editor Integration** - Replaced basic markdown textareas with a full-featured rich text editor powered by MDXEditor:
   - **Rich Text Editing** - WYSIWYG editing experience with live preview for markdown content

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pimzino/spec-workflow-mcp",
-  "version": "2.0.11",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pimzino/spec-workflow-mcp",
-      "version": "2.0.11",
+      "version": "2.1.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@dnd-kit/core": "^6.1.0",
@@ -22,7 +22,7 @@
         "chokidar": "^3.5.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "diff": "^5.1.0",
+        "diff": "^5.2.0",
         "fastify": "^4.24.3",
         "highlight.js": "^11.9.0",
         "howler": "^2.2.4",
@@ -45,7 +45,7 @@
       },
       "devDependencies": {
         "@tailwindcss/typography": "^0.5.16",
-        "@types/diff": "^5.0.3",
+        "@types/diff": "^5.2.3",
         "@types/node": "^22.18.1",
         "@types/react": "^18.3.5",
         "@types/react-dom": "^18.3.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chokidar": "^3.5.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "diff": "^5.1.0",
+    "diff": "^5.2.0",
     "fastify": "^4.24.3",
     "highlight.js": "^11.9.0",
     "howler": "^2.2.4",
@@ -75,7 +75,7 @@
   },
   "devDependencies": {
     "@tailwindcss/typography": "^0.5.16",
-    "@types/diff": "^5.0.3",
+    "@types/diff": "^5.2.3",
     "@types/node": "^22.18.1",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",


### PR DESCRIPTION
## Summary

Fixes #158 - In the review of revised documents, even if just one line is added, it appeared as if all subsequent text had been changed.

## Root Cause

The previous implementation used a naive index-based line comparison that compared lines by position (\romLines[i]\ vs \	oLines[i]\). When a line was inserted at the beginning or middle of a document, all subsequent lines would shift positions and appear as changed.

## Solution

Replaced the basic line-by-line comparison with the proper \diffLines\ function from the \diff\ library, which uses the Myers diff algorithm (LCS-based) to correctly identify the minimum set of changes between two documents.

## Changes

- **\src/dashboard/approval-storage.ts\**: Replaced manual index-based diff with \diffLines()\ from the \diff\ library
- **\package.json\**: Updated \diff\ from \^5.1.0\ to \^5.2.0\ and \@types/diff\ from \^5.0.3\ to \^5.2.3\
- **\CHANGELOG.md\**: Documented the fix under version 2.1.0

## Testing

- Build passes successfully
- The diff now correctly shows only actual changed lines, not positional differences