### PR TITLE
fix(approvals): reduce Codex Transport closed incidents on approvals

### DIFF
--- a/src/dashboard/approval-storage.ts
+++ b/src/dashboard/approval-storage.ts
@@ -497,7 +497,7 @@ export class ApprovalStorage extends EventEmitter {
     if (trigger === 'initial') {
       const existingInitial = metadata.snapshots.find(s => s.trigger === 'initial');
       if (existingInitial) {
-        console.log(`Initial snapshot already exists for ${approval.filePath}, skipping creation`);
+        console.error(`Initial snapshot already exists for ${approval.filePath}, skipping creation`);
         return;
       }
     }


### PR DESCRIPTION
## Summary

When running `approvals` via Codex, the MCP transport could close unexpectedly ("Transport closed") in some environments.

## Change

- Move the "initial snapshot already exists" log off `stdout` (use `console.error` instead of `console.log`).

## Why

Codex/MCP clients rely on `stdout` for protocol communication. Avoiding non-protocol output on `stdout` reduces the chance of client-side transport closure during approvals flows.

## How to reproduce / verify

1. From Codex, create a test approval request via `approvals` (an initial snapshot is created).
2. In the dashboard, mark it as `needs-revision` and add a comment.
3. Update the document and create a NEW approval request for the same file.
4. Run `approvals` again from Codex.
5. Confirm the tool completes without Codex reporting "Transport closed".

## Notes

- No changes to approval data or behavior; logging destination only.
