### PR TITLE
feat: Add tool annotations for improved LLM tool understanding

### DIFF
--- a/src/tools/approvals.ts
+++ b/src/tools/approvals.ts
@@ -78,6 +78,10 @@ CRITICAL: Only provide filePath parameter for requests - the dashboard reads fil
       }
     },
     required: ['action']
+  },
+  annotations: {
+    title: 'Approvals',
+    destructiveHint: true,
   }
 };
 

--- a/src/tools/log-implementation.ts
+++ b/src/tools/log-implementation.ts
@@ -283,6 +283,10 @@ Task: "Implemented logs dashboard with real-time updates"
       }
     },
     required: ['specName', 'taskId', 'summary', 'filesModified', 'filesCreated', 'statistics', 'artifacts']
+  },
+  annotations: {
+    title: 'Log Implementation',
+    destructiveHint: true,
   }
 };
 

--- a/src/tools/spec-status.ts
+++ b/src/tools/spec-status.ts
@@ -12,16 +12,20 @@ Call when resuming work on a spec or checking overall completion status. Shows w
   inputSchema: {
     type: 'object',
     properties: {
-      projectPath: { 
+      projectPath: {
         type: 'string',
         description: 'Absolute path to the project root (optional - uses server context path if not provided)'
       },
-      specName: { 
+      specName: {
         type: 'string',
         description: 'Name of the specification'
       }
     },
     required: ['specName']
+  },
+  annotations: {
+    title: 'Spec Status',
+    readOnlyHint: true,
   }
 };
 

--- a/src/tools/spec-workflow-guide.ts
+++ b/src/tools/spec-workflow-guide.ts
@@ -11,6 +11,10 @@ Call this tool FIRST when users request spec creation, feature development, or m
     type: 'object',
     properties: {},
     additionalProperties: false
+  },
+  annotations: {
+    title: 'Spec Workflow Guide',
+    readOnlyHint: true,
   }
 };
 

--- a/src/tools/steering-guide.ts
+++ b/src/tools/steering-guide.ts
@@ -11,6 +11,10 @@ Call ONLY when user explicitly requests steering document creation or asks about
     type: 'object',
     properties: {},
     additionalProperties: false
+  },
+  annotations: {
+    title: 'Steering Guide',
+    readOnlyHint: true,
   }
 };
 


### PR DESCRIPTION
## Summary

Adds MCP tool annotations (`readOnlyHint`, `destructiveHint`, `title`) to all 5 tools to help LLMs better understand tool behavior and make safer decisions about tool execution.

## Changes

| Tool | Annotation | Reason |
|------|------------|--------|
| `spec-workflow-guide` | `readOnlyHint: true` | Only loads workflow guide text |
| `steering-guide` | `readOnlyHint: true` | Only loads steering guide text |
| `spec-status` | `readOnlyHint: true` | Reads spec status from filesystem |
| `approvals` | `destructiveHint: true` | Creates/deletes approval requests |
| `log-implementation` | `destructiveHint: true` | Creates log entries (writes files) |

## Why This Matters

- Annotations provide semantic metadata that helps LLMs understand tool behavior
- MCP clients like Claude Code can auto-approve read-only tools without user confirmation
- Destructive tools trigger confirmation prompts for safer execution
- Enables better tool discovery and filtering by characteristics

## Testing

- [x] Server builds successfully (`npm run build`)
- [x] **Live verification:** Started server and confirmed `tools/list` returns annotations for all 5 tools
- [x] Annotation values match actual tool behavior

## Verification Output

```
Total tools: 5

Tool Name                 Title                     ReadOnly   Destructive
----------------------------------------------------------------------
spec-workflow-guide       Spec Workflow Guide       True       N/A       
steering-guide            Steering Guide            True       N/A       
spec-status               Spec Status               True       N/A       
approvals                 Approvals                 N/A        True      
log-implementation        Log Implementation        N/A        True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)