### PR TITLE
fix: resolve relative paths in resolveGitRoot()

### DIFF
--- a/src/core/__tests__/git-utils.test.ts
+++ b/src/core/__tests__/git-utils.test.ts
@@ -102,6 +102,14 @@ describe('resolveGitRoot', () => {
 
       expect(result).toBe('C:/Users/dev/main-repo');
     });
+
+    it('should resolve relative paths from git-common-dir', () => {
+      mockedExecSync.mockReturnValue('../../.git');
+
+      const result = resolveGitRoot('/home/user/repo/src/core');
+
+      expect(result).toBe('/home/user/repo');
+    });
   });
 
   describe('error handling', () => {

--- a/src/core/git-utils.ts
+++ b/src/core/git-utils.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import { resolve, isAbsolute } from 'path';
 
 export const SPEC_WORKFLOW_SHARED_ROOT_ENV = 'SPEC_WORKFLOW_SHARED_ROOT';
 
@@ -30,11 +31,16 @@ export function resolveGitRoot(projectPath: string): string {
       return projectPath;
     }
 
-    // In worktree, returns absolute path like "/main/.git" or "/main/.git/worktrees/name"
-    // Extract the main repo path (parent of .git)
+    // In worktree, returns path like "/main/.git", "../../.git", or "C:/main/.git"
+    // Extract the main repo path (parent of .git) and resolve to absolute path
     const gitIndex = gitCommonDir.lastIndexOf('.git');
     if (gitIndex > 0) {
-      return gitCommonDir.substring(0, gitIndex - 1);
+      const mainRepoPath = gitCommonDir.substring(0, gitIndex - 1);
+      // If already absolute (Unix or Windows), return as-is; otherwise resolve relative to projectPath
+      if (isAbsolute(mainRepoPath) || /^[A-Za-z]:/.test(mainRepoPath)) {
+        return mainRepoPath;
+      }
+      return resolve(projectPath, mainRepoPath);
     }
 
     return projectPath;


### PR DESCRIPTION
This PR addresses #189.

@Pimzino, I had some time and put together a fix, but I see you're already working on one. If you prefer your own approach, just let me know and I'll close this — no worries at all!

## Changes

- Use `path.resolve()` to convert relative paths to absolute paths in `resolveGitRoot()`
- Preserve already-absolute paths (both Unix and Windows style)
- Add test case for relative path handling

## Context

When running from a subdirectory, `git rev-parse --git-common-dir` may return a relative path (e.g., `../../.git`). The current implementation returns this as-is, which fails the path traversal check in `validateProjectPath()`.

The path traversal check was designed to prevent malicious user input, but `resolveGitRoot()` output comes from git itself.

Tested in:
- Main repository subdirectory ✓
- Git worktree root ✓
- Git worktree subdirectory ✓

Fixes #189
