### PR TITLE
fix: enforce log-implementation before marking tasks complete

### DIFF
--- a/src/prompts/implement-task.ts
+++ b/src/prompts/implement-task.ts
@@ -104,23 +104,10 @@ ${context.dashboardUrl ? `- Dashboard: ${context.dashboardUrl}` : ''}
    - Follow existing patterns in the codebase
    - Test your implementation thoroughly
 
-6. **Complete the Task:**
-   - Verify all success criteria from the _Prompt are met
-   - Run any relevant tests to ensure nothing is broken
-   - Edit .spec-workflow/specs/${specName}/tasks.md directly
-   - Change the task marker from [-] to [x] for the completed task
-   - Only mark complete when fully implemented and tested
-
-7. **Log Implementation (CRITICAL - ARTIFACTS REQUIRED):**
-   - After completing a task, use the log-implementation tool to record comprehensive implementation details
-   - This creates a searchable knowledge base for future AI agents to discover and reuse existing code
-   - You MUST include artifacts (required field) to enable other agents to find your work:
-     - **apiEndpoints**: List all API endpoints created/modified with method, path, purpose, request/response formats, and location
-     - **components**: List all UI components created with name, type, purpose, props, and location
-     - **functions**: List all utility functions with signature and location
-     - **classes**: List all classes with methods and location
-     - **integrations**: Document how frontend connects to backend with data flow description
-   - Call log-implementation with:
+6. **Log Implementation (MANDATORY - must complete BEFORE marking task done):**
+   - ⚠️ **STOP: Do NOT mark the task [x] until this step succeeds.**
+   - A task without an implementation log is NOT complete. Skipping this step is the #1 workflow violation.
+   - Call log-implementation with ALL of the following:
      - specName: "${specName}"
      - taskId: ${taskId ? `"${taskId}"` : 'the task ID you just completed'}
      - summary: Clear description of what was implemented (1-2 sentences)
@@ -128,6 +115,12 @@ ${context.dashboardUrl ? `- Dashboard: ${context.dashboardUrl}` : ''}
      - filesCreated: List of files you created
      - statistics: {linesAdded: number, linesRemoved: number}
      - artifacts: {apiEndpoints: [...], components: [...], functions: [...], classes: [...], integrations: [...]}
+   - You MUST include artifacts (required field) to enable other agents to find your work:
+     - **apiEndpoints**: List all API endpoints created/modified with method, path, purpose, request/response formats, and location
+     - **components**: List all UI components created with name, type, purpose, props, and location
+     - **functions**: List all utility functions with signature and location
+     - **classes**: List all classes with methods and location
+     - **integrations**: Document how frontend connects to backend with data flow description
    - Example artifacts for an API endpoint:
      \`\`\`json
      "apiEndpoints": [{
@@ -140,12 +133,22 @@ ${context.dashboardUrl ? `- Dashboard: ${context.dashboardUrl}` : ''}
      }]
      \`\`\`
    - Why: Future AI agents will query logs before implementing, preventing duplicate code and ensuring architecture consistency
+   - This creates a searchable knowledge base — without it, implementation knowledge is lost when the conversation ends
+
+7. **Complete the Task (only after step 6 succeeds):**
+   - Confirm that log-implementation returned success in step 6
+   - Verify all success criteria from the _Prompt are met
+   - Run any relevant tests to ensure nothing is broken
+   - Edit .spec-workflow/specs/${specName}/tasks.md directly
+   - Change the task marker from [-] to [x] for the completed task
+   - ⚠️ If you skipped step 6, go back now — a task marked [x] without a log is incomplete
 
 **Important Guidelines:**
 - Always mark a task as in-progress before starting work
 - Follow the _Prompt field guidance for role, approach, and success criteria
 - Use existing patterns and utilities mentioned in _Leverage fields
 - Test your implementation before marking the task complete
+- **ALWAYS call log-implementation BEFORE marking a task [x]** — this is the most-skipped step and it is mandatory
 - If a task has subtasks (e.g., 4.1, 4.2), complete them in order
 - If you encounter blockers, document them and move to another task
 
@@ -153,7 +156,7 @@ ${context.dashboardUrl ? `- Dashboard: ${context.dashboardUrl}` : ''}
 - spec-status: Check overall progress
 - Bash (grep/ripgrep): CRITICAL - Search existing implementations before coding (step 4)
 - Read: Examine markdown implementation log files directly (step 4)
-- log-implementation: Record implementation details with artifacts after task completion (step 7)
+- log-implementation: MANDATORY - Record implementation details with artifacts BEFORE marking task complete (step 6)
 - Edit: Directly update task markers in tasks.md file
 - Read/Write/Edit: Implement the actual code changes
 - Bash: Run tests and verify implementation

--- a/src/tools/spec-workflow-guide.ts
+++ b/src/tools/spec-workflow-guide.ts
@@ -235,7 +235,9 @@ flowchart TD
    - Follow _Leverage fields to use existing code/utilities
    - Implement the code according to the task description
    - Test your implementation
-   - **Log implementation with detailed artifacts** using log-implementation tool (CRITICAL):
+   - **MANDATORY: Log implementation BEFORE marking task complete** using log-implementation tool:
+     - ⚠️ Do NOT change [-] to [x] until log-implementation returns success
+     - A task without an implementation log is NOT complete — this is the most commonly skipped step
      - Provide taskId and clear summary of what was implemented (1-2 sentences)
      - Include files modified/created and code statistics (lines added/removed)
      - **REQUIRED: Include artifacts field with structured implementation data**:
@@ -247,7 +249,7 @@ flowchart TD
      - Example: "Created API GET /api/todos/:id endpoint and TodoDetail React component with WebSocket real-time updates"
      - This creates a searchable knowledge base for future AI agents to discover existing code
      - Prevents implementation details from being lost in chat history
-   - Edit tasks.md: Change \`[-]\` to \`[x]\` when completed and logged
+   - **Only after log-implementation succeeds**: Edit tasks.md: Change \`[-]\` to \`[x]\`
 4. Continue until all tasks show \`[x]\`
 
 ## Workflow Rules
@@ -262,6 +264,7 @@ flowchart TD
 - Approval requests: provide filePath only, never content
 - BLOCKING: Never proceed if approval delete fails
 - CRITICAL: Must have approved status AND successful cleanup before next phase
+- CRITICAL: Every task marked [x] MUST have a corresponding implementation log — call log-implementation BEFORE changing [-] to [x]
 - CRITICAL: Verbal approval is NEVER accepted - dashboard or VS Code extension only
 - NEVER proceed on user saying "approved" - check system status only
 - Steering docs are optional - only create when explicitly requested


### PR DESCRIPTION
## Summary

- Reorders steps 6 and 7 in `implement-task.ts` so `log-implementation` is called **before** marking a task `[x]`, not after
- Adds stop warnings and enforcement language to prevent AI agents from skipping the logging step
- Adds a workflow rule in `spec-workflow-guide.ts` making implementation logs mandatory

## Problem

The `implement-task` prompt listed steps in this order:
1. Step 6: "Complete the Task" — mark `[-]` to `[x]`
2. Step 7: "Log Implementation" — call `log-implementation`

AI agents follow numbered steps sequentially. They execute step 6 (mark complete), consider the task done, and never reach step 7. Across dozens of specs, **zero implementation logs** were being created.

The Mermaid workflow diagram in `spec-workflow-guide.ts` already showed the correct order (log → mark complete) — this PR aligns the text instructions to match the diagram.

## Changes

### `src/prompts/implement-task.ts`
- **Step 6** is now "Log Implementation" (was "Complete the Task")
- **Step 7** is now "Complete the Task" (was "Log Implementation")
- Added stop warning: "Do NOT mark the task [x] until this step succeeds"
- Added to Important Guidelines: "ALWAYS call log-implementation BEFORE marking a task [x]"
- Updated Tools list to emphasize logging is MANDATORY, not optional

### `src/tools/spec-workflow-guide.ts`
- Phase 4 instructions now say "MANDATORY: Log implementation BEFORE marking task complete"
- Added warning: "Do NOT change [-] to [x] until log-implementation returns success"
- Changed final mark-complete bullet to "Only after log-implementation succeeds"
- Added workflow rule: "Every task marked [x] MUST have a corresponding implementation log"

## Why this matters

Implementation logs are the knowledge base that prevents future AI agents from duplicating work. Without them, every new session starts from zero context. This was the #1 most-skipped workflow step because the prompt ordering made it easy for agents to skip.

## Test plan

- [ ] Verify `implement-task` prompt renders steps in correct order (log first, mark complete second)
- [ ] Verify `spec-workflow-guide` Phase 4 text matches the Mermaid diagram ordering
- [ ] Run through a full spec implementation and confirm the agent calls `log-implementation` before marking `[x]`

Closes #199