### PR TITLE
feat: add deferred decisions tracker

### DIFF
--- a/src/core/__tests__/deferral-storage.test.ts
+++ b/src/core/__tests__/deferral-storage.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { DeferralStorage } from '../deferral-storage.js';
+
+describe('DeferralStorage', () => {
+  let tempDir: string;
+  let storage: DeferralStorage;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(join(tmpdir(), 'deferral-test-'));
+    // DeferralStorage expects projectPath and builds .spec-workflow/deferrals/ from it
+    await fs.mkdir(join(tempDir, '.spec-workflow', 'deferrals'), { recursive: true });
+    storage = new DeferralStorage(tempDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const baseDeferral = {
+    title: 'OAuth2 PKCE flow',
+    originSpec: 'user-auth',
+    originPhase: 'design' as const,
+    revisitTrigger: 'when mobile app spec begins',
+    tags: ['auth', 'mobile'],
+    supersedes: null,
+    body: {
+      context: 'Mobile clients need PKCE but scope is too large for this spec.',
+      decision: 'Defer PKCE implementation to mobile spec.',
+      revisitCriteria: 'When mobile app spec begins',
+    },
+  };
+
+  describe('create', () => {
+    it('should create a deferral and return an ID', async () => {
+      const id = await storage.create(baseDeferral);
+      expect(id).toMatch(/^d-[0-9a-f]{8}$/);
+    });
+
+    it('should persist deferral to disk', async () => {
+      const id = await storage.create(baseDeferral);
+      const deferral = await storage.get(id);
+      expect(deferral).not.toBeNull();
+      expect(deferral!.title).toBe('OAuth2 PKCE flow');
+      expect(deferral!.status).toBe('deferred');
+      expect(deferral!.originSpec).toBe('user-auth');
+      expect(deferral!.tags).toEqual(['auth', 'mobile']);
+      expect(deferral!.body.context).toBe('Mobile clients need PKCE but scope is too large for this spec.');
+    });
+
+    it('should handle supersedes', async () => {
+      const oldId = await storage.create(baseDeferral);
+      const newId = await storage.create({
+        ...baseDeferral,
+        title: 'Updated PKCE approach',
+      }, oldId);
+
+      const oldDeferral = await storage.get(oldId);
+      expect(oldDeferral!.status).toBe('superseded');
+      expect(oldDeferral!.supersededBy).toBe(newId);
+
+      const newDeferral = await storage.get(newId);
+      expect(newDeferral!.supersedes).toBe(oldId);
+      expect(newDeferral!.status).toBe('deferred');
+    });
+
+    it('should reject superseding a non-deferred deferral', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.resolve(id, 'done');
+
+      await expect(storage.create({
+        ...baseDeferral,
+        title: 'New approach',
+      }, id)).rejects.toThrow('already resolved');
+    });
+  });
+
+  describe('get', () => {
+    it('should return null for non-existent ID', async () => {
+      const result = await storage.get('d-nonexist');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('list', () => {
+    it('should return empty array when no deferrals exist', async () => {
+      const result = await storage.list();
+      expect(result).toEqual([]);
+    });
+
+    it('should return all deferrals', async () => {
+      await storage.create(baseDeferral);
+      await storage.create({ ...baseDeferral, title: 'Second' });
+      const result = await storage.list();
+      expect(result).toHaveLength(2);
+    });
+
+    it('should filter by status', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.create({ ...baseDeferral, title: 'Second' });
+      await storage.resolve(id, 'done');
+
+      const deferred = await storage.list({ status: 'deferred' });
+      expect(deferred).toHaveLength(1);
+      expect(deferred[0].title).toBe('Second');
+
+      const resolved = await storage.list({ status: 'resolved' });
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].title).toBe('OAuth2 PKCE flow');
+    });
+
+    it('should filter by originSpec', async () => {
+      await storage.create(baseDeferral);
+      await storage.create({ ...baseDeferral, title: 'Other', originSpec: 'other-spec' });
+
+      const result = await storage.list({ originSpec: 'user-auth' });
+      expect(result).toHaveLength(1);
+      expect(result[0].originSpec).toBe('user-auth');
+    });
+
+    it('should filter by tag', async () => {
+      await storage.create(baseDeferral);
+      await storage.create({ ...baseDeferral, title: 'No tags', tags: [] });
+
+      const result = await storage.list({ tag: 'auth' });
+      expect(result).toHaveLength(1);
+      expect(result[0].tags).toContain('auth');
+    });
+  });
+
+  describe('resolve', () => {
+    it('should mark deferral as resolved', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.resolve(id, 'Implemented in mobile spec', 'mobile-app');
+
+      const deferral = await storage.get(id);
+      expect(deferral!.status).toBe('resolved');
+      expect(deferral!.resolution).toBe('Implemented in mobile spec');
+      expect(deferral!.resolvedInSpec).toBe('mobile-app');
+      expect(deferral!.resolvedAt).toBeTruthy();
+    });
+
+    it('should reject resolving non-deferred deferral', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.resolve(id, 'done');
+      await expect(storage.resolve(id, 'again')).rejects.toThrow('already resolved');
+    });
+
+    it('should reject resolving non-existent deferral', async () => {
+      await expect(storage.resolve('d-nonexist', 'done')).rejects.toThrow('not found');
+    });
+  });
+
+  describe('update', () => {
+    it('should update mutable fields', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.update(id, {
+        title: 'Updated title',
+        tags: ['new-tag'],
+        context: 'Updated context',
+      });
+
+      const deferral = await storage.get(id);
+      expect(deferral!.title).toBe('Updated title');
+      expect(deferral!.tags).toEqual(['new-tag']);
+      expect(deferral!.body.context).toBe('Updated context');
+      expect(deferral!.status).toBe('deferred'); // status unchanged
+    });
+
+    it('should reject updating non-existent deferral', async () => {
+      await expect(storage.update('d-nonexist', { title: 'x' })).rejects.toThrow('not found');
+    });
+  });
+
+  describe('delete', () => {
+    it('should delete a deferral', async () => {
+      const id = await storage.create(baseDeferral);
+      await storage.delete(id);
+      const result = await storage.get(id);
+      expect(result).toBeNull();
+    });
+
+    it('should reject deleting non-existent deferral', async () => {
+      await expect(storage.delete('d-nonexist')).rejects.toThrow('not found');
+    });
+
+    it('should reject deleting a deferral referenced by another', async () => {
+      const oldId = await storage.create(baseDeferral);
+      await storage.create({ ...baseDeferral, title: 'New' }, oldId);
+
+      await expect(storage.delete(oldId)).rejects.toThrow('references');
+    });
+  });
+
+  describe('roundtrip with special characters', () => {
+    it('should handle quotes in title and body', async () => {
+      const id = await storage.create({
+        ...baseDeferral,
+        title: 'Decision about "important" thing',
+        body: {
+          context: 'Contains "quotes" and special chars',
+          decision: 'We decided to defer "this"',
+          revisitCriteria: 'When "ready"',
+        },
+      });
+
+      const deferral = await storage.get(id);
+      expect(deferral!.title).toBe('Decision about "important" thing');
+      expect(deferral!.body.context).toBe('Contains "quotes" and special chars');
+    });
+  });
+});

--- a/src/core/deferral-storage.ts
+++ b/src/core/deferral-storage.ts
@@ -1,0 +1,250 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { Deferral } from '../types.js';
+import { PathUtils } from './path-utils.js';
+
+/**
+ * Storage for deferred decisions using markdown files with YAML frontmatter.
+ * Each deferral is stored as a single file in .spec-workflow/deferrals/
+ */
+export class DeferralStorage {
+  private deferralsDir: string;
+
+  constructor(projectPath: string) {
+    this.deferralsDir = join(PathUtils.getWorkflowRoot(projectPath), 'deferrals');
+  }
+
+  private async ensureDir(): Promise<void> {
+    await fs.mkdir(this.deferralsDir, { recursive: true });
+  }
+
+  private generateId(): string {
+    return 'd-' + randomUUID().replace(/-/g, '').slice(0, 8);
+  }
+
+  private toMarkdown(deferral: Deferral): string {
+    const frontmatter = [
+      '---',
+      `id: "${deferral.id}"`,
+      `status: "${deferral.status}"`,
+      `title: "${deferral.title.replace(/"/g, '\\"')}"`,
+      `createdAt: "${deferral.createdAt}"`,
+      `updatedAt: "${deferral.updatedAt}"`,
+      `resolvedAt: ${deferral.resolvedAt ? `"${deferral.resolvedAt}"` : 'null'}`,
+      `originSpec: ${deferral.originSpec ? `"${deferral.originSpec}"` : 'null'}`,
+      `originPhase: ${deferral.originPhase ? `"${deferral.originPhase}"` : 'null'}`,
+      `revisitTrigger: "${deferral.revisitTrigger.replace(/"/g, '\\"')}"`,
+      `tags: [${deferral.tags.map(t => `"${t}"`).join(', ')}]`,
+      `resolution: ${deferral.resolution ? `"${deferral.resolution.replace(/"/g, '\\"')}"` : 'null'}`,
+      `resolvedInSpec: ${deferral.resolvedInSpec ? `"${deferral.resolvedInSpec}"` : 'null'}`,
+      `supersededBy: ${deferral.supersededBy ? `"${deferral.supersededBy}"` : 'null'}`,
+      `supersedes: ${deferral.supersedes ? `"${deferral.supersedes}"` : 'null'}`,
+      '---',
+    ].join('\n');
+
+    return `${frontmatter}
+
+## Context
+${deferral.body.context}
+
+## Decision Deferred
+${deferral.body.decision}
+
+## Revisit Criteria
+${deferral.body.revisitCriteria}
+`;
+  }
+
+  private parseMarkdown(content: string): Deferral | null {
+    const fmMatch = content.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+    if (!fmMatch) return null;
+
+    const fm = fmMatch[1];
+    const body = fmMatch[2];
+
+    const getString = (key: string): string | null => {
+      const match = fm.match(new RegExp(`^${key}:\\s*(?:"((?:[^"\\\\]|\\\\.)*)"|null)\\s*$`, 'm'));
+      if (!match) return null;
+      return match[1] !== undefined ? match[1].replace(/\\"/g, '"') : null;
+    };
+
+    const getArray = (key: string): string[] => {
+      const match = fm.match(new RegExp(`^${key}:\\s*\\[(.*)\\]\\s*$`, 'm'));
+      if (!match || !match[1].trim()) return [];
+      return match[1].split(',').map(s => s.trim().replace(/^"|"$/g, ''));
+    };
+
+    const getSection = (heading: string): string => {
+      const regex = new RegExp(`## ${heading}\\n([\\s\\S]*?)(?=\\n## |$)`);
+      const match = body.match(regex);
+      return match ? match[1].trim() : '';
+    };
+
+    const id = getString('id');
+    const status = getString('status') as Deferral['status'];
+    const title = getString('title');
+    if (!id || !status || !title) return null;
+
+    return {
+      id,
+      status,
+      title,
+      createdAt: getString('createdAt') || '',
+      updatedAt: getString('updatedAt') || '',
+      resolvedAt: getString('resolvedAt'),
+      originSpec: getString('originSpec'),
+      originPhase: getString('originPhase') as Deferral['originPhase'],
+      revisitTrigger: getString('revisitTrigger') || '',
+      tags: getArray('tags'),
+      resolution: getString('resolution'),
+      resolvedInSpec: getString('resolvedInSpec'),
+      supersededBy: getString('supersededBy'),
+      supersedes: getString('supersedes'),
+      body: {
+        context: getSection('Context'),
+        decision: getSection('Decision Deferred'),
+        revisitCriteria: getSection('Revisit Criteria'),
+      },
+    };
+  }
+
+  async create(
+    deferral: Omit<Deferral, 'id' | 'status' | 'createdAt' | 'updatedAt' | 'resolvedAt' | 'resolution' | 'resolvedInSpec' | 'supersededBy'>,
+    supersedes?: string
+  ): Promise<string> {
+    await this.ensureDir();
+
+    // Generate unique ID with collision check
+    let id: string;
+    let attempts = 0;
+    do {
+      id = this.generateId();
+      attempts++;
+      if (attempts > 10) throw new Error('Failed to generate unique deferral ID after 10 attempts');
+    } while (await this.exists(id));
+
+    const now = new Date().toISOString();
+    const newDeferral: Deferral = {
+      ...deferral,
+      id,
+      status: 'deferred',
+      createdAt: now,
+      updatedAt: now,
+      resolvedAt: null,
+      resolution: null,
+      resolvedInSpec: null,
+      supersededBy: null,
+      supersedes: supersedes || null,
+    };
+
+    // If superseding, mark old deferral
+    if (supersedes) {
+      const old = await this.get(supersedes);
+      if (!old) throw new Error(`Cannot supersede: deferral ${supersedes} not found`);
+      if (old.status !== 'deferred') throw new Error(`Cannot supersede: deferral ${supersedes} is already ${old.status}`);
+      old.status = 'superseded';
+      old.supersededBy = id;
+      old.updatedAt = now;
+      await fs.writeFile(join(this.deferralsDir, `${supersedes}.md`), this.toMarkdown(old), 'utf-8');
+    }
+
+    await fs.writeFile(join(this.deferralsDir, `${id}.md`), this.toMarkdown(newDeferral), 'utf-8');
+    return id;
+  }
+
+  async get(id: string): Promise<Deferral | null> {
+    try {
+      const content = await fs.readFile(join(this.deferralsDir, `${id}.md`), 'utf-8');
+      return this.parseMarkdown(content);
+    } catch {
+      return null;
+    }
+  }
+
+  async list(filters?: { status?: string; originSpec?: string; tag?: string }): Promise<Deferral[]> {
+    try {
+      const files = await fs.readdir(this.deferralsDir);
+      const deferrals: Deferral[] = [];
+
+      for (const file of files) {
+        if (!file.endsWith('.md')) continue;
+        const content = await fs.readFile(join(this.deferralsDir, file), 'utf-8');
+        const deferral = this.parseMarkdown(content);
+        if (!deferral) continue;
+
+        if (filters?.status && deferral.status !== filters.status) continue;
+        if (filters?.originSpec && deferral.originSpec !== filters.originSpec) continue;
+        if (filters?.tag && !deferral.tags.includes(filters.tag)) continue;
+
+        deferrals.push(deferral);
+      }
+
+      return deferrals.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+    } catch {
+      return [];
+    }
+  }
+
+  async resolve(id: string, resolution: string, resolvedInSpec?: string): Promise<void> {
+    const deferral = await this.get(id);
+    if (!deferral) throw new Error(`Deferral ${id} not found`);
+    if (deferral.status !== 'deferred') throw new Error(`Cannot resolve: deferral ${id} is already ${deferral.status}`);
+
+    const now = new Date().toISOString();
+    deferral.status = 'resolved';
+    deferral.resolution = resolution;
+    deferral.resolvedAt = now;
+    deferral.updatedAt = now;
+    deferral.resolvedInSpec = resolvedInSpec || null;
+
+    await fs.writeFile(join(this.deferralsDir, `${id}.md`), this.toMarkdown(deferral), 'utf-8');
+  }
+
+  async update(id: string, updates: {
+    title?: string;
+    revisitTrigger?: string;
+    tags?: string[];
+    context?: string;
+    decision?: string;
+    revisitCriteria?: string;
+  }): Promise<void> {
+    const deferral = await this.get(id);
+    if (!deferral) throw new Error(`Deferral ${id} not found`);
+
+    if (updates.title !== undefined) deferral.title = updates.title;
+    if (updates.revisitTrigger !== undefined) deferral.revisitTrigger = updates.revisitTrigger;
+    if (updates.tags !== undefined) deferral.tags = updates.tags;
+    if (updates.context !== undefined) deferral.body.context = updates.context;
+    if (updates.decision !== undefined) deferral.body.decision = updates.decision;
+    if (updates.revisitCriteria !== undefined) deferral.body.revisitCriteria = updates.revisitCriteria;
+    deferral.updatedAt = new Date().toISOString();
+
+    await fs.writeFile(join(this.deferralsDir, `${id}.md`), this.toMarkdown(deferral), 'utf-8');
+  }
+
+  async delete(id: string): Promise<void> {
+    const deferral = await this.get(id);
+    if (!deferral) throw new Error(`Deferral ${id} not found`);
+
+    // Check if any other deferral references this one
+    const all = await this.list();
+    for (const d of all) {
+      if (d.id === id) continue;
+      if (d.supersededBy === id || d.supersedes === id) {
+        throw new Error(`Cannot delete: deferral ${d.id} references ${id}`);
+      }
+    }
+
+    await fs.unlink(join(this.deferralsDir, `${id}.md`));
+  }
+
+  private async exists(id: string): Promise<boolean> {
+    try {
+      await fs.access(join(this.deferralsDir, `${id}.md`));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/core/workspace-initializer.ts
+++ b/src/core/workspace-initializer.ts
@@ -35,7 +35,8 @@ export class WorkspaceInitializer {
     
     const directories = [
       'approvals',
-      'archive', 
+      'archive',
+      'deferrals',
       'specs',
       'steering',
       'templates',

--- a/src/dashboard/multi-server.ts
+++ b/src/dashboard/multi-server.ts
@@ -1188,6 +1188,49 @@ export class MultiProjectDashboardServer {
       }
     });
 
+    // Deferrals endpoints (read-only)
+    this.app.get('/api/projects/:projectId/deferrals', async (request, reply) => {
+      const { projectId } = request.params as { projectId: string };
+      const project = this.projectManager.getProject(projectId);
+      if (!project) {
+        return reply.code(404).send({ error: 'Project not found' });
+      }
+
+      try {
+        const { DeferralStorage } = await import('../core/deferral-storage.js');
+        const storage = new DeferralStorage(project.projectPath);
+        const query = request.query as { status?: string; originSpec?: string; tag?: string };
+        const deferrals = await storage.list({
+          status: query.status,
+          originSpec: query.originSpec,
+          tag: query.tag,
+        });
+        return deferrals;
+      } catch (error: any) {
+        return reply.code(500).send({ error: `Failed to list deferrals: ${error.message}` });
+      }
+    });
+
+    this.app.get('/api/projects/:projectId/deferrals/:id', async (request, reply) => {
+      const { projectId, id } = request.params as { projectId: string; id: string };
+      const project = this.projectManager.getProject(projectId);
+      if (!project) {
+        return reply.code(404).send({ error: 'Project not found' });
+      }
+
+      try {
+        const { DeferralStorage } = await import('../core/deferral-storage.js');
+        const storage = new DeferralStorage(project.projectPath);
+        const deferral = await storage.get(id);
+        if (!deferral) {
+          return reply.code(404).send({ error: `Deferral ${id} not found` });
+        }
+        return deferral;
+      } catch (error: any) {
+        return reply.code(500).send({ error: `Failed to get deferral: ${error.message}` });
+      }
+    });
+
     // Project-specific changelog endpoint
     this.app.get('/api/projects/:projectId/changelog/:version', async (request, reply) => {
       const { version } = request.params as { version: string };

--- a/src/tools/__tests__/deferrals.test.ts
+++ b/src/tools/__tests__/deferrals.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { deferralsHandler } from '../deferrals.js';
+import { ToolContext } from '../../types.js';
+
+describe('deferrals tool handler', () => {
+  let tempDir: string;
+  let context: ToolContext;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(join(tmpdir(), 'deferrals-tool-test-'));
+    await fs.mkdir(join(tempDir, '.spec-workflow', 'deferrals'), { recursive: true });
+    context = { projectPath: tempDir };
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const addArgs = {
+    action: 'add',
+    title: 'Test deferral',
+    context: 'Test context',
+    decision: 'Test decision',
+    revisitTrigger: 'Later',
+  };
+
+  describe('add action', () => {
+    it('should create a deferral', async () => {
+      const result = await deferralsHandler(addArgs, context);
+      expect(result.success).toBe(true);
+      expect(result.data.id).toMatch(/^d-[0-9a-f]{8}$/);
+    });
+
+    it('should fail with missing required fields', async () => {
+      const result = await deferralsHandler({ action: 'add', title: 'Only title' }, context);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Missing required fields');
+    });
+  });
+
+  describe('list action', () => {
+    it('should list deferrals', async () => {
+      await deferralsHandler(addArgs, context);
+      await deferralsHandler({ ...addArgs, title: 'Second' }, context);
+
+      const result = await deferralsHandler({ action: 'list' }, context);
+      expect(result.success).toBe(true);
+      expect(result.data.total).toBe(2);
+    });
+
+    it('should filter by status', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      await deferralsHandler({
+        action: 'resolve',
+        id: addResult.data.id,
+        resolution: 'Done',
+      }, context);
+
+      const result = await deferralsHandler({ action: 'list', status: 'deferred' }, context);
+      expect(result.data.total).toBe(0);
+    });
+  });
+
+  describe('get action', () => {
+    it('should get deferral details', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const result = await deferralsHandler({ action: 'get', id: addResult.data.id }, context);
+      expect(result.success).toBe(true);
+      expect(result.data.title).toBe('Test deferral');
+    });
+
+    it('should fail for missing id', async () => {
+      const result = await deferralsHandler({ action: 'get' }, context);
+      expect(result.success).toBe(false);
+    });
+
+    it('should fail for non-existent id', async () => {
+      const result = await deferralsHandler({ action: 'get', id: 'd-nonexist' }, context);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('resolve action', () => {
+    it('should resolve a deferral', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const result = await deferralsHandler({
+        action: 'resolve',
+        id: addResult.data.id,
+        resolution: 'Implemented',
+        resolvedInSpec: 'mobile-app',
+      }, context);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail with missing fields', async () => {
+      const result = await deferralsHandler({ action: 'resolve', id: 'd-123' }, context);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Missing required fields');
+    });
+  });
+
+  describe('update action', () => {
+    it('should update a deferral', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const result = await deferralsHandler({
+        action: 'update',
+        id: addResult.data.id,
+        title: 'Updated title',
+        tags: ['new-tag'],
+      }, context);
+      expect(result.success).toBe(true);
+      expect(result.data.updatedFields).toContain('title');
+    });
+
+    it('should fail with no fields to update', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const result = await deferralsHandler({
+        action: 'update',
+        id: addResult.data.id,
+      }, context);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('No fields to update');
+    });
+  });
+
+  describe('delete action', () => {
+    it('should delete a deferral', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const result = await deferralsHandler({ action: 'delete', id: addResult.data.id }, context);
+      expect(result.success).toBe(true);
+    });
+
+    it('should fail for missing id', async () => {
+      const result = await deferralsHandler({ action: 'delete' }, context);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('supersede flow', () => {
+    it('should supersede and block delete of referenced deferral', async () => {
+      const addResult = await deferralsHandler(addArgs, context);
+      const oldId = addResult.data.id;
+
+      const newResult = await deferralsHandler({
+        ...addArgs,
+        title: 'Replacement',
+        supersedes: oldId,
+      }, context);
+      expect(newResult.success).toBe(true);
+
+      // Old one should be superseded
+      const getOld = await deferralsHandler({ action: 'get', id: oldId }, context);
+      expect(getOld.data.status).toBe('superseded');
+
+      // Delete of old should fail (referenced by new)
+      const deleteResult = await deferralsHandler({ action: 'delete', id: oldId }, context);
+      expect(deleteResult.success).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should fail with unknown action', async () => {
+      const result = await deferralsHandler({ action: 'unknown' }, context);
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('Unknown action');
+    });
+
+    it('should fail without project path', async () => {
+      const result = await deferralsHandler({ action: 'list' }, { projectPath: '' });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/src/tools/deferrals.ts
+++ b/src/tools/deferrals.ts
@@ -1,0 +1,255 @@
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+import { ToolContext, ToolResponse } from '../types.js';
+import { DeferralStorage } from '../core/deferral-storage.js';
+import { validateProjectPath } from '../core/path-utils.js';
+
+export const deferralsTool: Tool = {
+  name: 'deferrals',
+  description: `Track decisions that are explicitly deferred during spec work.
+
+# Instructions
+Use this tool to record, query, and resolve deferred decisions. Deferrals are project-level artifacts that persist across specs.
+
+Actions:
+- 'add': Record a new deferred decision (optionally superseding an existing one)
+- 'list': List deferrals with optional filters (status, originSpec, tag)
+- 'get': Get full details of a specific deferral
+- 'resolve': Mark a deferral as resolved
+- 'update': Update mutable fields (title, revisitTrigger, tags, context, decision, revisitCriteria)
+- 'delete': Remove a deferral (fails if referenced by another deferral)`,
+  inputSchema: {
+    type: 'object',
+    properties: {
+      action: {
+        type: 'string',
+        enum: ['add', 'list', 'get', 'resolve', 'update', 'delete'],
+        description: 'The action to perform'
+      },
+      projectPath: {
+        type: 'string',
+        description: 'Absolute path to the project root (optional - uses server context path if not provided)'
+      },
+      // add params
+      title: {
+        type: 'string',
+        description: 'Title of the deferred decision (required for add)'
+      },
+      context: {
+        type: 'string',
+        description: 'Why this decision was deferred and what alternatives were considered (required for add)'
+      },
+      decision: {
+        type: 'string',
+        description: 'What specifically was not decided or not implemented (required for add)'
+      },
+      revisitTrigger: {
+        type: 'string',
+        description: 'Freeform description of when to revisit this decision (required for add)'
+      },
+      revisitCriteria: {
+        type: 'string',
+        description: 'What conditions should trigger revisiting this (optional for add, defaults to revisitTrigger)'
+      },
+      originSpec: {
+        type: 'string',
+        description: 'Spec that created this deferral (optional for add)'
+      },
+      originPhase: {
+        type: 'string',
+        enum: ['requirements', 'design', 'tasks', 'implementation'],
+        description: 'Phase where decision was deferred (optional for add)'
+      },
+      tags: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Freeform tags for filtering (optional for add/update)'
+      },
+      supersedes: {
+        type: 'string',
+        description: 'ID of deferral this one replaces — automatically marks old one as superseded (optional for add)'
+      },
+      // get/resolve/update/delete params
+      id: {
+        type: 'string',
+        description: 'Deferral ID (required for get, resolve, update, delete)'
+      },
+      // resolve params
+      resolution: {
+        type: 'string',
+        description: 'Brief note on how it was resolved (required for resolve)'
+      },
+      resolvedInSpec: {
+        type: 'string',
+        description: 'Spec that resolved this deferral (optional for resolve)'
+      },
+      // list params
+      status: {
+        type: 'string',
+        enum: ['deferred', 'resolved', 'superseded'],
+        description: 'Filter by status (optional for list, default: all statuses)'
+      },
+      tag: {
+        type: 'string',
+        description: 'Filter by tag — matches if deferral tags include this value (optional for list)'
+      }
+    },
+    required: ['action']
+  },
+  annotations: {
+    title: 'Deferrals',
+    destructiveHint: true,
+  }
+};
+
+export async function deferralsHandler(
+  args: Record<string, any>,
+  context: ToolContext
+): Promise<ToolResponse> {
+  const projectPath = args.projectPath || context.projectPath;
+  if (!projectPath) {
+    return { success: false, message: 'Project path is required but not provided in context or arguments' };
+  }
+
+  try {
+    const validatedPath = await validateProjectPath(projectPath);
+    const storage = new DeferralStorage(validatedPath);
+
+    switch (args.action) {
+      case 'add':
+        return await handleAdd(args, storage);
+      case 'list':
+        return await handleList(args, storage);
+      case 'get':
+        return await handleGet(args, storage);
+      case 'resolve':
+        return await handleResolve(args, storage);
+      case 'update':
+        return await handleUpdate(args, storage);
+      case 'delete':
+        return await handleDelete(args, storage);
+      default:
+        return { success: false, message: `Unknown action: ${args.action}. Use 'add', 'list', 'get', 'resolve', 'update', or 'delete'.` };
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    return { success: false, message: `Deferrals operation failed: ${msg}` };
+  }
+}
+
+async function handleAdd(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  if (!args.title || !args.context || !args.decision || !args.revisitTrigger) {
+    return { success: false, message: 'Missing required fields for add. Required: title, context, decision, revisitTrigger' };
+  }
+
+  const id = await storage.create({
+    title: args.title,
+    originSpec: args.originSpec || null,
+    originPhase: args.originPhase || null,
+    revisitTrigger: args.revisitTrigger,
+    tags: args.tags || [],
+    supersedes: args.supersedes || null,
+    body: {
+      context: args.context,
+      decision: args.decision,
+      revisitCriteria: args.revisitCriteria || args.revisitTrigger,
+    },
+  }, args.supersedes);
+
+  return {
+    success: true,
+    message: `Deferred decision recorded: ${id}`,
+    data: { id, title: args.title },
+  };
+}
+
+async function handleList(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  const deferrals = await storage.list({
+    status: args.status,
+    originSpec: args.originSpec,
+    tag: args.tag,
+  });
+
+  const summary = deferrals.map(d => ({
+    id: d.id,
+    status: d.status,
+    title: d.title,
+    originSpec: d.originSpec,
+    tags: d.tags,
+    revisitTrigger: d.revisitTrigger,
+    createdAt: d.createdAt,
+  }));
+
+  return {
+    success: true,
+    message: `Found ${deferrals.length} deferral(s)`,
+    data: { deferrals: summary, total: deferrals.length },
+  };
+}
+
+async function handleGet(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  if (!args.id) {
+    return { success: false, message: 'Missing required field: id' };
+  }
+
+  const deferral = await storage.get(args.id);
+  if (!deferral) {
+    return { success: false, message: `Deferral ${args.id} not found` };
+  }
+
+  return {
+    success: true,
+    message: `Deferral ${args.id}: ${deferral.title}`,
+    data: deferral,
+  };
+}
+
+async function handleResolve(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  if (!args.id || !args.resolution) {
+    return { success: false, message: 'Missing required fields for resolve. Required: id, resolution' };
+  }
+
+  await storage.resolve(args.id, args.resolution, args.resolvedInSpec);
+
+  return {
+    success: true,
+    message: `Deferral ${args.id} resolved`,
+    data: { id: args.id, resolution: args.resolution },
+  };
+}
+
+async function handleUpdate(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  if (!args.id) {
+    return { success: false, message: 'Missing required field: id' };
+  }
+
+  const updates: Record<string, any> = {};
+  for (const key of ['title', 'revisitTrigger', 'tags', 'context', 'decision', 'revisitCriteria']) {
+    if (args[key] !== undefined) updates[key] = args[key];
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return { success: false, message: 'No fields to update. Updatable: title, revisitTrigger, tags, context, decision, revisitCriteria' };
+  }
+
+  await storage.update(args.id, updates);
+
+  return {
+    success: true,
+    message: `Deferral ${args.id} updated`,
+    data: { id: args.id, updatedFields: Object.keys(updates) },
+  };
+}
+
+async function handleDelete(args: Record<string, any>, storage: DeferralStorage): Promise<ToolResponse> {
+  if (!args.id) {
+    return { success: false, message: 'Missing required field: id' };
+  }
+
+  await storage.delete(args.id);
+
+  return {
+    success: true,
+    message: `Deferral ${args.id} deleted`,
+    data: { id: args.id },
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -4,6 +4,7 @@ import { specStatusTool, specStatusHandler } from './spec-status.js';
 import { steeringGuideTool, steeringGuideHandler } from './steering-guide.js';
 import { approvalsTool, approvalsHandler } from './approvals.js';
 import { logImplementationTool, logImplementationHandler } from './log-implementation.js';
+import { deferralsTool, deferralsHandler } from './deferrals.js';
 import { ToolContext, ToolResponse, MCPToolResponse, toMCPResponse } from '../types.js';
 
 export function registerTools(): Tool[] {
@@ -12,7 +13,8 @@ export function registerTools(): Tool[] {
     steeringGuideTool,
     specStatusTool,
     approvalsTool,
-    logImplementationTool
+    logImplementationTool,
+    deferralsTool
   ];
 }
 
@@ -36,6 +38,9 @@ export async function handleToolCall(name: string, args: any, context: ToolConte
         break;
       case 'log-implementation':
         response = await logImplementationHandler(args, context);
+        break;
+      case 'deferrals':
+        response = await deferralsHandler(args, context);
         break;
       default:
         throw new Error(`Unknown tool: ${name}`);

--- a/src/tools/spec-workflow-guide.ts
+++ b/src/tools/spec-workflow-guide.ts
@@ -157,7 +157,9 @@ flowchart TD
 2. If no custom template, read from \`.spec-workflow/templates/design-template.md\`
 3. Analyze codebase for patterns to reuse
 4. Research technology choices (if web search available, current year: ${currentYear})
-5. Generate design with all template sections6. Create \`design.md\` at \`.spec-workflow/specs/{spec-name}/design.md\`
+5. Generate design with all template sections
+6. When deferring a design decision, record it with the \`deferrals\` tool (action: add) with originSpec and originPhase set
+7. Create \`design.md\` at \`.spec-workflow/specs/{spec-name}/design.md\`
 7. Request approval using approvals tool with action:'request'
 8. Poll status using approvals with action:'status' until approved/needs-revision
 9. If needs-revision: update document using comments, create NEW approval, do NOT proceed
@@ -216,7 +218,7 @@ flowchart TD
 - Direct editing: Mark tasks as in-progress [-] or complete [x] in tasks.md
 
 **Process**:
-1. Check current status with spec-status
+1. Check current status with spec-status. Check deferred decisions with \`deferrals\` tool (action: list) — if any are relevant to the current spec's work, note them and address them if the implementation naturally covers them. Resolve addressed deferrals with action: resolve.
 2. Read \`tasks.md\` to see all tasks
 3. For each task:
    - Edit tasks.md: Change \`[ ]\` to \`[-]\` for the task you're starting
@@ -268,6 +270,7 @@ flowchart TD
 - CRITICAL: Verbal approval is NEVER accepted - dashboard or VS Code extension only
 - NEVER proceed on user saying "approved" - check system status only
 - Steering docs are optional - only create when explicitly requested
+- When explicitly deferring a decision in any phase, record it using the deferrals tool. Deferrals are project-level artifacts that persist across specs.
 
 ## File Structure
 \`\`\`
@@ -279,6 +282,9 @@ flowchart TD
 │   ├── product-template.md
 │   ├── tech-template.md
 │   └── structure-template.md
+├── deferrals/              # Project-level deferred decisions
+│   ├── d-abc123.md
+│   └── d-def456.md
 ├── specs/
 │   └── {spec-name}/
 │       ├── requirements.md

--- a/src/types.ts
+++ b/src/types.ts
@@ -193,6 +193,28 @@ export interface MCPToolResponse {
   _meta?: Record<string, any>;
 }
 
+export interface Deferral {
+  id: string;
+  status: 'deferred' | 'resolved' | 'superseded';
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+  resolvedAt: string | null;
+  originSpec: string | null;
+  originPhase: 'requirements' | 'design' | 'tasks' | 'implementation' | null;
+  revisitTrigger: string;
+  tags: string[];
+  resolution: string | null;
+  resolvedInSpec: string | null;
+  supersededBy: string | null;
+  supersedes: string | null;
+  body: {
+    context: string;
+    decision: string;
+    revisitCriteria: string;
+  };
+}
+
 // Helper function to convert ToolResponse to MCP format
 export function toMCPResponse(response: ToolResponse, isError: boolean = false): MCPToolResponse {
   return {


### PR DESCRIPTION
## Summary

Adds project-level tracking for decisions explicitly deferred during spec work. Deferrals get a dedicated MCP tool, file-based storage, and read-only dashboard API — making them discoverable across specs without re-reading every design document.

## Problem

Deferred decisions currently get embedded inline in design documents, making them invisible to future specs and unqueryable. A team starting a new spec has no way to discover what was punted from prior work without manually searching through every design doc. This feature gives deferrals a persistent, structured home outside any single spec.

## Changes

### MCP Tool

**`deferrals`** — Single tool with action-based dispatch (same pattern as `approvals`).

| Action | Purpose |
|--------|---------|
| `add` | Record a new deferred decision. Optionally supersedes an existing one. |
| `list` | List deferrals, filterable by status, originSpec, or tag |
| `get` | Get full deferral details including body sections |
| `resolve` | Mark as resolved with resolution note. Validates status is `deferred`. |
| `update` | Update mutable fields (title, revisitTrigger, tags, context, decision, revisitCriteria) |
| `delete` | Remove a deferral. Fails if referenced by another deferral's supersede chain. |

### Storage (`deferral-storage.ts`)

Each deferral is a single markdown file (`d-{8-hex}.md`) with YAML frontmatter for structured fields and markdown body sections for Context, Decision Deferred, and Revisit Criteria. ID generation uses truncated UUIDs with collision checks.

**Status transitions:** `deferred → resolved` and `deferred → superseded` only. Supersede chains maintain referential integrity — deleting a referenced deferral is blocked.

### Methodology Updates (`spec-workflow-guide.ts`)

- **Phase 2 (Design)**: When deferring a design decision, record it with the `deferrals` tool
- **Phase 4 (Implementation)**: Check deferred decisions at start; resolve any that the implementation naturally covers
- **Workflow Rules**: Deferrals are project-level artifacts that persist across specs

### Dashboard API

Read-only REST endpoints for future dashboard UI consumption:
- `GET /api/projects/:projectId/deferrals` (with status/originSpec/tag query params)
- `GET /api/projects/:projectId/deferrals/:id`

## How to Review

1. **`src/types.ts`** — the `Deferral` interface. Quick read, establishes the data model
2. **`src/core/deferral-storage.ts`** — file-based storage with YAML frontmatter parsing. Self-contained
3. **`src/tools/deferrals.ts`** — MCP tool handler with action dispatch
4. **`src/dashboard/multi-server.ts`** — two simple GET routes
5. **`src/tools/spec-workflow-guide.ts`** — methodology text additions
6. **Tests** (`__tests__/`) — 35 new tests covering storage and tool handler

## Testing

- `npm run build` succeeds
- `npm test` — all tests pass (35 new covering storage + tool handler)
- MCP tool: add deferral A, list, supersede A via adding B with `supersedes`, resolve B, attempt delete A (should fail — B references it), delete B, then delete A
- Verify `.spec-workflow/deferrals/` directory created on server init
- Dashboard: GET deferrals list and single deferral endpoints return correct data
