### PR TITLE
feat: add Pending Revisions section to approvals dashboard

### DIFF
--- a/src/dashboard/approval-storage.ts
+++ b/src/dashboard/approval-storage.ts
@@ -467,7 +467,7 @@ export class ApprovalStorage extends EventEmitter {
   async getAllPendingApprovals(): Promise<ApprovalRequest[]> {
     const allApprovals = await this.getAllApprovals();
     return allApprovals.filter(approval =>
-      approval.status === 'pending'
+      approval.status === 'pending' || approval.status === 'needs-revision'
     );
   }
 

--- a/src/dashboard_frontend/src/locales/en.json
+++ b/src/dashboard_frontend/src/locales/en.json
@@ -397,6 +397,7 @@
     },
     "revisions": {
       "header": "Pending Revisions",
+      "description": "These items are awaiting revision by the agent. No actions are available until revisions are complete.",
       "count_one": "{{count}} awaiting revision",
       "count_other": "{{count}} awaiting revision"
     },

--- a/src/dashboard_frontend/src/locales/en.json
+++ b/src/dashboard_frontend/src/locales/en.json
@@ -395,6 +395,11 @@
       "title": "No Pending Approvals",
       "description": "All approvals have been processed. New approval requests will appear here."
     },
+    "revisions": {
+      "header": "Pending Revisions",
+      "count_one": "{{count}} awaiting revision",
+      "count_other": "{{count}} awaiting revision"
+    },
     "reject": {
       "title": "Reject Approval",
       "placeholder": "Please provide feedback explaining why this is being rejected...",

--- a/src/dashboard_frontend/src/modules/pages/ApprovalsPage.tsx
+++ b/src/dashboard_frontend/src/modules/pages/ApprovalsPage.tsx
@@ -685,6 +685,17 @@ function Content() {
     return filtered;
   }, [approvals, filterCategory]);
 
+  // Filter approvals with needs-revision status (with same category filter)
+  const revisionApprovals = useMemo(() => {
+    let filtered = approvals.filter(a => a.status === 'needs-revision');
+
+    if (filterCategory !== 'all') {
+      filtered = filtered.filter(a => (a as any).categoryName === filterCategory);
+    }
+
+    return filtered;
+  }, [approvals, filterCategory]);
+
   // Calculate pending count for header display
   const pendingCount = useMemo(() => {
     return filteredApprovals.filter(a => a.status === 'pending').length;
@@ -1010,6 +1021,33 @@ function Content() {
               isHighlighted={highlightedId === a.id}
             />
           ))}
+        </div>
+      )}
+
+      {/* Pending Revisions Section */}
+      {revisionApprovals.length > 0 && (
+        <div className="grid gap-4 max-w-full overflow-x-hidden">
+          <div className="bg-[var(--surface-panel)] border border-[var(--border-default)] shadow rounded-lg p-3 sm:p-4 md:p-6 max-w-full overflow-x-hidden">
+            <div className="flex items-center gap-3">
+              <h3 className="text-base sm:text-lg font-semibold text-[var(--text-primary)]">{t('approvalsPage.revisions.header')}</h3>
+              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--status-warning-muted)] text-[var(--status-warning)]">
+                {t('approvalsPage.revisions.count', { count: revisionApprovals.length })}
+              </span>
+            </div>
+          </div>
+          <div className="space-y-3 sm:space-y-4 max-w-full overflow-x-hidden">
+            {revisionApprovals.map((a) => (
+              <ApprovalItem
+                key={a.id}
+                a={a}
+                selectionMode={false}
+                isSelected={false}
+                selectedCount={0}
+                onToggleSelection={handleToggleSelection}
+                isHighlighted={highlightedId === a.id}
+              />
+            ))}
+          </div>
         </div>
       )}
 

--- a/src/dashboard_frontend/src/modules/pages/ApprovalsPage.tsx
+++ b/src/dashboard_frontend/src/modules/pages/ApprovalsPage.tsx
@@ -20,9 +20,10 @@ interface ApprovalItemProps {
   selectedCount: number;
   onToggleSelection: (id: string) => void;
   isHighlighted: boolean;
+  readOnly?: boolean;
 }
 
-function ApprovalItem({ a, selectionMode, isSelected, selectedCount, onToggleSelection, isHighlighted }: ApprovalItemProps) {
+function ApprovalItem({ a, selectionMode, isSelected, selectedCount, onToggleSelection, isHighlighted, readOnly = false }: ApprovalItemProps) {
   const { approvalsAction, getApprovalContent, getApprovalSnapshots, getApprovalDiff, reloadAll } = useApi();
   const { showNotification } = useNotifications();
   const { t } = useTranslation();
@@ -315,6 +316,7 @@ function ApprovalItem({ a, selectionMode, isSelected, selectedCount, onToggleSel
             </div>
 
             {/* Action Buttons */}
+            {!readOnly && (
             <div className="flex flex-wrap items-center gap-3 min-w-0">
               <button
                 onClick={() => setOpen(!open)}
@@ -395,6 +397,7 @@ function ApprovalItem({ a, selectionMode, isSelected, selectedCount, onToggleSel
                 </button>
               )}
             </div>
+            )}
           </div>
         </div>
       </div>
@@ -1027,12 +1030,19 @@ function Content() {
       {/* Pending Revisions Section */}
       {revisionApprovals.length > 0 && (
         <div className="grid gap-4 max-w-full overflow-x-hidden">
-          <div className="bg-[var(--surface-panel)] border border-[var(--border-default)] shadow rounded-lg p-3 sm:p-4 md:p-6 max-w-full overflow-x-hidden">
-            <div className="flex items-center gap-3">
-              <h3 className="text-base sm:text-lg font-semibold text-[var(--text-primary)]">{t('approvalsPage.revisions.header')}</h3>
-              <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--status-warning-muted)] text-[var(--status-warning)]">
-                {t('approvalsPage.revisions.count', { count: revisionApprovals.length })}
-              </span>
+          <div className="bg-[var(--surface-panel)] border border-[var(--border-default)] shadow rounded-lg p-3 sm:p-4 md:p-6 lg:p-8 max-w-full overflow-x-hidden">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+              <div className="flex-1 min-w-0">
+                <h2 className="text-lg sm:text-xl md:text-2xl font-semibold text-[var(--text-primary)]">{t('approvalsPage.revisions.header')}</h2>
+                <p className="text-sm text-[var(--text-muted)] mt-1">
+                  {t('approvalsPage.revisions.description')}
+                </p>
+              </div>
+              <div className="flex items-center gap-2 sm:gap-3">
+                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-[var(--status-warning-muted)] text-[var(--status-warning)]">
+                  {t('approvalsPage.revisions.count', { count: revisionApprovals.length })}
+                </span>
+              </div>
             </div>
           </div>
           <div className="space-y-3 sm:space-y-4 max-w-full overflow-x-hidden">
@@ -1045,6 +1055,7 @@ function Content() {
                 selectedCount={0}
                 onToggleSelection={handleToggleSelection}
                 isHighlighted={highlightedId === a.id}
+                readOnly
               />
             ))}
           </div>


### PR DESCRIPTION
## Overview

When a user requests revisions on an approval, the item's status changes to `needs-revision` and it disappears from the dashboard entirely. The only way to know revisions were requested is to remember — there's no visual tracking. This adds a dedicated "Pending Revisions" section below the existing approvals list so users can see all in-flight items at a glance.

## Summary

- Expand `getAllPendingApprovals()` to return both `pending` and `needs-revision` approvals
- Add a "Pending Revisions" section below the existing "Pending Approvals" list on the dashboard
- Reuse the existing `ApprovalItem` component for revision items (no new UI components)
- Add i18n strings for the new section header and count badge

## Details

### Backend

The `getAllPendingApprovals()` method in `ApprovalStorage` filtered to `status === 'pending'` only. Updated the filter to also include `status === 'needs-revision'`. No new endpoints — the existing `/api/projects/:projectId/approvals` route now returns both statuses.

### Frontend

Two changes in `ApprovalsPage.tsx`:

1. **New `revisionApprovals` memo** — filters the approvals array for `needs-revision` status, respecting the existing category filter
2. **New section in the render tree** — appears below the pending approvals list when there are revision items. Includes a header with count badge (same warning-color styling as the pending badge). Selection mode is disabled for revision items since they're waiting on the agent, not the user.

### i18n

Added `approvalsPage.revisions.header`, `.count_one`, and `.count_other` to `en.json`.

## Test Plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm test` — all existing tests pass
- [ ] Request revisions on an approval — verify it moves from "Pending Approvals" to "Pending Revisions"
- [ ] Verify category filter applies to both sections
- [ ] Verify the revisions section is hidden when no items have `needs-revision` status
- [ ] Verify pending approvals continue to display and function normally
