### PR TITLE
fix: remove stack-specific bias and add requirement traceability to spec template

### DIFF
--- a/src/markdown/templates/design-template.md
+++ b/src/markdown/templates/design-template.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[High-level description of the feature and its place in the overall system]
+[High-level description of the feature: what it does, where it fits in the system, and which requirements it addresses. 2-4 sentences.]
 
 ## Steering Document Alignment
 
@@ -10,28 +10,26 @@
 [How the design follows documented technical patterns and standards]
 
 ### Project Structure (structure.md)
-[How the implementation will follow project organization conventions]
+[How the implementation follows project organization conventions]
 
 ## Code Reuse Analysis
-[What existing code will be leveraged, extended, or integrated with this feature]
 
-### Existing Components to Leverage
-- **[Component/Utility Name]**: [How it will be used]
-- **[Service/Helper Name]**: [How it will be extended]
+<!-- List existing code that this feature will use, extend, or integrate with.
+     Include file paths. This prevents the implementation from rebuilding
+     what already exists. -->
 
-### Integration Points
-- **[Existing System/API]**: [How the new feature will integrate]
-- **[Database/Storage]**: [How data will connect to existing schemas]
+| Existing code | How it's used |
+|---|---|
+| [path/to/file] | [Reused as-is / Extended / Integrated via ...] |
+| [path/to/file] | [Reused as-is / Extended / Integrated via ...] |
 
 ## Architecture
 
-[Describe the overall architecture and design patterns used]
+<!-- Include a diagram ONLY if the feature involves non-obvious data flow,
+     multiple interacting components, or cross-feature coordination.
+     Omit for straightforward CRUD or single-component features. -->
 
-### Modular Design Principles
-- **Single File Responsibility**: Each file should handle one specific concern or domain
-- **Component Isolation**: Create small, focused components rather than large monolithic files
-- **Service Layer Separation**: Separate data access, business logic, and presentation layers
-- **Utility Modularity**: Break utilities into focused, single-purpose modules
+[Describe the overall architecture and design patterns used]
 
 ```mermaid
 graph TD
@@ -39,58 +37,63 @@ graph TD
     B --> C[Component C]
 ```
 
-## Components and Interfaces
+## Components
 
-### Component 1
-- **Purpose:** [What this component does]
-- **Interfaces:** [Public methods/APIs]
-- **Dependencies:** [What it depends on]
-- **Reuses:** [Existing components/utilities it builds upon]
+<!-- For each component, specify the file path and which requirements it addresses.
+     The implementing agent needs paths and requirement traceability, not just descriptions. -->
 
-### Component 2
+### [Component Name]
+- **File(s):** [path/to/file(s) to create or modify]
 - **Purpose:** [What this component does]
-- **Interfaces:** [Public methods/APIs]
+- **Interfaces:** [Public methods/APIs/props]
 - **Dependencies:** [What it depends on]
-- **Reuses:** [Existing components/utilities it builds upon]
+- **Reuses:** [Existing code it builds upon, from Code Reuse Analysis]
+- **Requirements:** [R1, R2.3, etc.]
+
+### [Component Name]
+- **File(s):** [path/to/file(s) to create or modify]
+- **Purpose:** [What this component does]
+- **Interfaces:** [Public methods/APIs/props]
+- **Dependencies:** [What it depends on]
+- **Reuses:** [Existing code it builds upon]
+- **Requirements:** [R1, R2.3, etc.]
+
+## API Endpoints
+
+<!-- Include this section if the feature adds or modifies API endpoints.
+     Omit entirely for features with no API surface. -->
+
+| Method | Path | Purpose | Request body | Response | Requirements |
+|---|---|---|---|---|---|
+| [GET/POST/...] | [/api/...] | [What it does] | [Schema or "none"] | [Shape] | [Rn] |
 
 ## Data Models
 
-### Model 1
-```
-[Define the structure of Model1 in your language]
-- id: [unique identifier type]
-- name: [string/text type]
-- [Additional properties as needed]
-```
+<!-- Include this section if the feature adds or modifies persistent data.
+     Omit for features with no data model changes. -->
 
-### Model 2
-```
-[Define the structure of Model2 in your language]
-- id: [unique identifier type]
-- [Additional properties as needed]
-```
+### [Model Name]
+- **Table/collection:** [name]
+- **Requirements:** [Rn]
+
+| Column/Field | Type | Constraints | Notes |
+|---|---|---|---|
+| [name] | [type] | [PK/FK/unique/nullable/default] | [purpose if not obvious] |
 
 ## Error Handling
 
-### Error Scenarios
-1. **Scenario 1:** [Description]
-   - **Handling:** [How to handle]
-   - **User Impact:** [What user sees]
+<!-- Only list error scenarios specific to this feature.
+     Reference the project's standard error handling pattern for common cases. -->
 
-2. **Scenario 2:** [Description]
-   - **Handling:** [How to handle]
-   - **User Impact:** [What user sees]
+| Scenario | Error type | Status | User impact |
+|---|---|---|---|
+| [What goes wrong] | [Error class/code] | [HTTP status or equivalent] | [What the user sees] |
 
 ## Testing Strategy
 
-### Unit Testing
-- [Unit testing approach]
-- [Key components to test]
+<!-- List what needs testing for this feature specifically.
+     Reference the project's testing patterns for how tests are structured. -->
 
-### Integration Testing
-- [Integration testing approach]
-- [Key flows to test]
-
-### End-to-End Testing
-- [E2E testing approach]
-- [User scenarios to test]
+- **Unit tests:** [What logic needs unit testing and why]
+- **Integration tests:** [What flows need integration testing]
+- **E2E tests:** [What user scenarios need E2E coverage, if any]

--- a/src/markdown/templates/requirements-template.md
+++ b/src/markdown/templates/requirements-template.md
@@ -2,15 +2,19 @@
 
 ## Introduction
 
-[Provide a brief overview of the feature, its purpose, and its value to users]
+[Brief overview: what this feature is, why it exists, and what value it provides. 2-3 sentences.]
 
 ## Alignment with Product Vision
 
-[Explain how this feature supports the goals outlined in product.md]
+[How this feature supports the goals in product.md. Reference specific objectives or principles by name.]
 
 ## Requirements
 
-### Requirement 1
+<!-- Number requirements as R1, R2, etc. Number acceptance criteria as R1.1, R1.2, etc.
+     These IDs are referenced by downstream design and tasks documents.
+     Use EARS format (WHEN/IF/THEN/SHALL) for acceptance criteria. -->
+
+### R1: [Requirement Name]
 
 **User Story:** As a [role], I want [feature], so that [benefit]
 
@@ -20,7 +24,7 @@
 2. IF [precondition] THEN [system] SHALL [response]
 3. WHEN [event] AND [condition] THEN [system] SHALL [response]
 
-### Requirement 2
+### R2: [Requirement Name]
 
 **User Story:** As a [role], I want [feature], so that [benefit]
 
@@ -31,20 +35,20 @@
 
 ## Non-Functional Requirements
 
-### Code Architecture and Modularity
-- **Single Responsibility Principle**: Each file should have a single, well-defined purpose
-- **Modular Design**: Components, utilities, and services should be isolated and reusable
-- **Dependency Management**: Minimize interdependencies between modules
-- **Clear Interfaces**: Define clean contracts between components and layers
+<!-- List NFRs specific to this feature. Reference steering docs for project-wide
+     architectural standards if they exist. Only include performance, security,
+     reliability, and usability requirements that go beyond project defaults or
+     are particularly important for this feature. Omit categories that have
+     nothing feature-specific to say. -->
 
 ### Performance
-- [Performance requirements]
+- [Feature-specific performance requirements, if any]
 
 ### Security
-- [Security requirements]
+- [Feature-specific security requirements, if any]
 
 ### Reliability
-- [Reliability requirements]
+- [Feature-specific reliability requirements, if any]
 
 ### Usability
-- [Usability requirements]
+- [Feature-specific usability requirements, if any]

--- a/src/markdown/templates/tasks-template.md
+++ b/src/markdown/templates/tasks-template.md
@@ -1,139 +1,52 @@
 # Tasks Document
 
-- [ ] 1. Create core interfaces in src/types/feature.ts
-  - File: src/types/feature.ts
-  - Define TypeScript interfaces for feature data structures
-  - Extend existing base interfaces from base.ts
-  - Purpose: Establish type safety for feature implementation
-  - _Leverage: src/types/base.ts_
-  - _Requirements: 1.1_
-  - _Prompt: Role: TypeScript Developer specializing in type systems and interfaces | Task: Create comprehensive TypeScript interfaces for the feature data structures following requirements 1.1, extending existing base interfaces from src/types/base.ts | Restrictions: Do not modify existing base interfaces, maintain backward compatibility, follow project naming conventions | Success: All interfaces compile without errors, proper inheritance from base types, full type coverage for feature requirements_
+<!-- Each task should:
+     - Touch 1-3 files (atomic scope)
+     - Map to specific requirements via _Requirements
+     - Include a _Prompt with structured fields for the implementing agent
+     - List files to create/modify and existing code to leverage
 
-- [ ] 2. Create base model class in src/models/FeatureModel.ts
-  - File: src/models/FeatureModel.ts
-  - Implement base model extending BaseModel class
-  - Add validation methods using existing validation utilities
-  - Purpose: Provide data layer foundation for feature
-  - _Leverage: src/models/BaseModel.ts, src/utils/validation.ts_
-  - _Requirements: 2.1_
-  - _Prompt: Role: Backend Developer with expertise in Node.js and data modeling | Task: Create a base model class extending BaseModel and implementing validation following requirement 2.1, leveraging existing patterns from src/models/BaseModel.ts and src/utils/validation.ts | Restrictions: Must follow existing model patterns, do not bypass validation utilities, maintain consistent error handling | Success: Model extends BaseModel correctly, validation methods implemented and tested, follows project architecture patterns_
+     Task status:
+     - [ ] = Pending
+     - [-] = In progress
+     - [x] = Complete
+-->
 
-- [ ] 3. Add specific model methods to FeatureModel.ts
-  - File: src/models/FeatureModel.ts (continue from task 2)
-  - Implement create, update, delete methods
-  - Add relationship handling for foreign keys
-  - Purpose: Complete model functionality for CRUD operations
-  - _Leverage: src/models/BaseModel.ts_
-  - _Requirements: 2.2, 2.3_
-  - _Prompt: Role: Backend Developer with expertise in ORM and database operations | Task: Implement CRUD methods and relationship handling in FeatureModel.ts following requirements 2.2 and 2.3, extending patterns from src/models/BaseModel.ts | Restrictions: Must maintain transaction integrity, follow existing relationship patterns, do not duplicate base model functionality | Success: All CRUD operations work correctly, relationships are properly handled, database operations are atomic and efficient_
+- [ ] 1. [Short task title]
+  - File(s): [path/to/file(s) to create or modify]
+  - [What to implement — 1-3 sentences]
+  - _Leverage: [paths to existing code to build on]_
+  - _Requirements: R1.1, R1.2_
+  - _Prompt:_
+    - _Role: [Relevant specialization for this task]_
+    - _Task: [Clear description with pointers to design doc sections and existing code]_
+    - _Restrictions: [What not to do, constraints to follow, boundaries to respect]_
+    - _Leverage: [Files and utilities to use — repeat from above for self-contained prompt]_
+    - _Requirements: [Requirements this task implements — repeat from above]_
+    - _Success: [Concrete, verifiable completion criteria]_
 
-- [ ] 4. Create model unit tests in tests/models/FeatureModel.test.ts
-  - File: tests/models/FeatureModel.test.ts
-  - Write tests for model validation and CRUD methods
-  - Use existing test utilities and fixtures
-  - Purpose: Ensure model reliability and catch regressions
-  - _Leverage: tests/helpers/testUtils.ts, tests/fixtures/data.ts_
-  - _Requirements: 2.1, 2.2_
-  - _Prompt: Role: QA Engineer with expertise in unit testing and Jest/Mocha frameworks | Task: Create comprehensive unit tests for FeatureModel validation and CRUD methods covering requirements 2.1 and 2.2, using existing test utilities from tests/helpers/testUtils.ts and fixtures from tests/fixtures/data.ts | Restrictions: Must test both success and failure scenarios, do not test external dependencies directly, maintain test isolation | Success: All model methods are tested with good coverage, edge cases covered, tests run independently and consistently_
+- [ ] 2. [Short task title]
+  - File(s): [path/to/file(s) to create or modify]
+  - [What to implement — 1-3 sentences]
+  - _Leverage: [paths to existing code to build on]_
+  - _Requirements: R2.1_
+  - _Prompt:_
+    - _Role: [Relevant specialization for this task]_
+    - _Task: [Clear description with context references]_
+    - _Restrictions: [Constraints]_
+    - _Leverage: [Files and utilities to use]_
+    - _Requirements: [Requirements this task implements]_
+    - _Success: [Completion criteria]_
 
-- [ ] 5. Create service interface in src/services/IFeatureService.ts
-  - File: src/services/IFeatureService.ts
-  - Define service contract with method signatures
-  - Extend base service interface patterns
-  - Purpose: Establish service layer contract for dependency injection
-  - _Leverage: src/services/IBaseService.ts_
-  - _Requirements: 3.1_
-  - _Prompt: Role: Software Architect specializing in service-oriented architecture and TypeScript interfaces | Task: Design service interface contract following requirement 3.1, extending base service patterns from src/services/IBaseService.ts for dependency injection | Restrictions: Must maintain interface segregation principle, do not expose internal implementation details, ensure contract compatibility with DI container | Success: Interface is well-defined with clear method signatures, extends base service appropriately, supports all required service operations_
-
-- [ ] 6. Implement feature service in src/services/FeatureService.ts
-  - File: src/services/FeatureService.ts
-  - Create concrete service implementation using FeatureModel
-  - Add error handling with existing error utilities
-  - Purpose: Provide business logic layer for feature operations
-  - _Leverage: src/services/BaseService.ts, src/utils/errorHandler.ts, src/models/FeatureModel.ts_
-  - _Requirements: 3.2_
-  - _Prompt: Role: Backend Developer with expertise in service layer architecture and business logic | Task: Implement concrete FeatureService following requirement 3.2, using FeatureModel and extending BaseService patterns with proper error handling from src/utils/errorHandler.ts | Restrictions: Must implement interface contract exactly, do not bypass model validation, maintain separation of concerns from data layer | Success: Service implements all interface methods correctly, robust error handling implemented, business logic is well-encapsulated and testable_
-
-- [ ] 7. Add service dependency injection in src/utils/di.ts
-  - File: src/utils/di.ts (modify existing)
-  - Register FeatureService in dependency injection container
-  - Configure service lifetime and dependencies
-  - Purpose: Enable service injection throughout application
-  - _Leverage: existing DI configuration in src/utils/di.ts_
-  - _Requirements: 3.1_
-  - _Prompt: Role: DevOps Engineer with expertise in dependency injection and IoC containers | Task: Register FeatureService in DI container following requirement 3.1, configuring appropriate lifetime and dependencies using existing patterns from src/utils/di.ts | Restrictions: Must follow existing DI container patterns, do not create circular dependencies, maintain service resolution efficiency | Success: FeatureService is properly registered and resolvable, dependencies are correctly configured, service lifetime is appropriate for use case_
-
-- [ ] 8. Create service unit tests in tests/services/FeatureService.test.ts
-  - File: tests/services/FeatureService.test.ts
-  - Write tests for service methods with mocked dependencies
-  - Test error handling scenarios
-  - Purpose: Ensure service reliability and proper error handling
-  - _Leverage: tests/helpers/testUtils.ts, tests/mocks/modelMocks.ts_
-  - _Requirements: 3.2, 3.3_
-  - _Prompt: Role: QA Engineer with expertise in service testing and mocking frameworks | Task: Create comprehensive unit tests for FeatureService methods covering requirements 3.2 and 3.3, using mocked dependencies from tests/mocks/modelMocks.ts and test utilities | Restrictions: Must mock all external dependencies, test business logic in isolation, do not test framework code | Success: All service methods tested with proper mocking, error scenarios covered, tests verify business logic correctness and error handling_
-
-- [ ] 4. Create API endpoints
-  - Design API structure
-  - _Leverage: src/api/baseApi.ts, src/utils/apiUtils.ts_
-  - _Requirements: 4.0_
-  - _Prompt: Role: API Architect specializing in RESTful design and Express.js | Task: Design comprehensive API structure following requirement 4.0, leveraging existing patterns from src/api/baseApi.ts and utilities from src/utils/apiUtils.ts | Restrictions: Must follow REST conventions, maintain API versioning compatibility, do not expose internal data structures directly | Success: API structure is well-designed and documented, follows existing patterns, supports all required operations with proper HTTP methods and status codes_
-
-- [ ] 4.1 Set up routing and middleware
-  - Configure application routes
-  - Add authentication middleware
-  - Set up error handling middleware
-  - _Leverage: src/middleware/auth.ts, src/middleware/errorHandler.ts_
-  - _Requirements: 4.1_
-  - _Prompt: Role: Backend Developer with expertise in Express.js middleware and routing | Task: Configure application routes and middleware following requirement 4.1, integrating authentication from src/middleware/auth.ts and error handling from src/middleware/errorHandler.ts | Restrictions: Must maintain middleware order, do not bypass security middleware, ensure proper error propagation | Success: Routes are properly configured with correct middleware chain, authentication works correctly, errors are handled gracefully throughout the request lifecycle_
-
-- [ ] 4.2 Implement CRUD endpoints
-  - Create API endpoints
-  - Add request validation
-  - Write API integration tests
-  - _Leverage: src/controllers/BaseController.ts, src/utils/validation.ts_
-  - _Requirements: 4.2, 4.3_
-  - _Prompt: Role: Full-stack Developer with expertise in API development and validation | Task: Implement CRUD endpoints following requirements 4.2 and 4.3, extending BaseController patterns and using validation utilities from src/utils/validation.ts | Restrictions: Must validate all inputs, follow existing controller patterns, ensure proper HTTP status codes and responses | Success: All CRUD operations work correctly, request validation prevents invalid data, integration tests pass and cover all endpoints_
-
-- [ ] 5. Add frontend components
-  - Plan component architecture
-  - _Leverage: src/components/BaseComponent.tsx, src/styles/theme.ts_
-  - _Requirements: 5.0_
-  - _Prompt: Role: Frontend Architect with expertise in React component design and architecture | Task: Plan comprehensive component architecture following requirement 5.0, leveraging base patterns from src/components/BaseComponent.tsx and theme system from src/styles/theme.ts | Restrictions: Must follow existing component patterns, maintain design system consistency, ensure component reusability | Success: Architecture is well-planned and documented, components are properly organized, follows existing patterns and theme system_
-
-- [ ] 5.1 Create base UI components
-  - Set up component structure
-  - Implement reusable components
-  - Add styling and theming
-  - _Leverage: src/components/BaseComponent.tsx, src/styles/theme.ts_
-  - _Requirements: 5.1_
-  - _Prompt: Role: Frontend Developer specializing in React and component architecture | Task: Create reusable UI components following requirement 5.1, extending BaseComponent patterns and using existing theme system from src/styles/theme.ts | Restrictions: Must use existing theme variables, follow component composition patterns, ensure accessibility compliance | Success: Components are reusable and properly themed, follow existing architecture, accessible and responsive_
-
-- [ ] 5.2 Implement feature-specific components
-  - Create feature components
-  - Add state management
-  - Connect to API endpoints
-  - _Leverage: src/hooks/useApi.ts, src/components/BaseComponent.tsx_
-  - _Requirements: 5.2, 5.3_
-  - _Prompt: Role: React Developer with expertise in state management and API integration | Task: Implement feature-specific components following requirements 5.2 and 5.3, using API hooks from src/hooks/useApi.ts and extending BaseComponent patterns | Restrictions: Must use existing state management patterns, handle loading and error states properly, maintain component performance | Success: Components are fully functional with proper state management, API integration works smoothly, user experience is responsive and intuitive_
-
-- [ ] 6. Integration and testing
-  - Plan integration approach
-  - _Leverage: src/utils/integrationUtils.ts, tests/helpers/testUtils.ts_
-  - _Requirements: 6.0_
-  - _Prompt: Role: Integration Engineer with expertise in system integration and testing strategies | Task: Plan comprehensive integration approach following requirement 6.0, leveraging integration utilities from src/utils/integrationUtils.ts and test helpers | Restrictions: Must consider all system components, ensure proper test coverage, maintain integration test reliability | Success: Integration plan is comprehensive and feasible, all system components work together correctly, integration points are well-tested_
-
-- [ ] 6.1 Write end-to-end tests
-  - Set up E2E testing framework
-  - Write user journey tests
-  - Add test automation
-  - _Leverage: tests/helpers/testUtils.ts, tests/fixtures/data.ts_
-  - _Requirements: All_
-  - _Prompt: Role: QA Automation Engineer with expertise in E2E testing and test frameworks like Cypress or Playwright | Task: Implement comprehensive end-to-end tests covering all requirements, setting up testing framework and user journey tests using test utilities and fixtures | Restrictions: Must test real user workflows, ensure tests are maintainable and reliable, do not test implementation details | Success: E2E tests cover all critical user journeys, tests run reliably in CI/CD pipeline, user experience is validated from end-to-end_
-
-- [ ] 6.2 Final integration and cleanup
-  - Integrate all components
-  - Fix any integration issues
-  - Clean up code and documentation
-  - _Leverage: src/utils/cleanup.ts, docs/templates/_
-  - _Requirements: All_
-  - _Prompt: Role: Senior Developer with expertise in code quality and system integration | Task: Complete final integration of all components and perform comprehensive cleanup covering all requirements, using cleanup utilities and documentation templates | Restrictions: Must not break existing functionality, ensure code quality standards are met, maintain documentation consistency | Success: All components are fully integrated and working together, code is clean and well-documented, system meets all requirements and quality standards_
+- [ ] 3. [Short task title]
+  - File(s): [path/to/file(s) to create or modify]
+  - [What to implement]
+  - _Leverage: [existing code paths]_
+  - _Requirements: R3.1, R3.2_
+  - _Prompt:_
+    - _Role: [Relevant specialization]_
+    - _Task: [Description with context]_
+    - _Restrictions: [Constraints]_
+    - _Leverage: [Files to use]_
+    - _Requirements: [Requirement IDs]_
+    - _Success: [Criteria]_


### PR DESCRIPTION
## Summary

This PR streamlines the three spec templates (requirements, design, tasks) to improve traceability between documents and reduce template bias toward any specific tech stack.

## Changes

**Tasks template** — Replaces the 17-task worked example (which assumed a TypeScript/Express/React CRUD app with DI and service layers) with 3 generic task slots. Keeps the structured `_Prompt:` format (Role/Task/Restrictions/Leverage/Requirements/Success) which is the useful part, without biasing toward a specific stack.

**Requirements template** — Adds stable requirement IDs (R1, R1.1, R1.2) so downstream design and task documents can reference requirements unambiguously. Removes hardcoded NFR categories that belong in steering docs, not repeated per-feature.

**Design template** — Adds `File(s):` and `Requirements:` fields to component sections so the implementing agent knows *where* to put code and *which requirement* it satisfies. Switches API endpoints, data models, and error handling to table format for consistent structure. Marks optional sections (API, data models) as omittable via HTML comments.

## Why

The spec workflow produces three linked documents — requirements, design, tasks — but the templates didn't enforce any concrete link between them. A task's `_Requirements: 2.1_` referenced a requirement heading called "Requirement 2" with no ID scheme, making traceability fragile and ambiguous.

The tasks template also presupposed a very specific architecture (base classes, service interfaces, DI containers, Express middleware, React components), which made the workflow harder to adopt for projects using different stacks or patterns.

Net result: -80 lines, stable cross-document references, and stack-agnostic templates.
