### PR TITLE
fix: prevent path traversal in approval categoryName (issue #220)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.7] - 2026-05-04
+
+### Security
+- **Fix Approval Category Path Traversal** (Issue #220) - Prevented writing approval files outside the `.spec-workflow/approvals` directory via crafted `categoryName` values:
+  - Added defense-in-depth validation at both the MCP tool handler (`src/tools/approvals.ts`) and the storage layer (`src/dashboard/approval-storage.ts`)
+  - Reject `categoryName` containing `..`, `/`, or `\` at the tool boundary with a clear security error
+  - Replaced all raw `join(this.approvalsDir, categoryName)` calls with `PathUtils.safeJoin()` which enforces path containment within the approvals directory
+  - Hardened `findApprovalPath()` and `getAllApprovals()` to skip directory entries that fail validation instead of crashing
+
 ## [2.2.6] - 2026-03-07
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pimzino/spec-workflow-mcp",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "MCP server for spec-driven development workflow with real-time web dashboard",
   "main": "dist/index.js",
   "type": "module",

--- a/src/core/__tests__/path-utils.test.ts
+++ b/src/core/__tests__/path-utils.test.ts
@@ -413,6 +413,27 @@ describe('PathUtils path traversal security', () => {
   });
 });
 
+describe('PathUtils.validateSimplePathSegment', () => {
+  it('accepts a simple category name', () => {
+    expect(() => PathUtils.validateSimplePathSegment('test-spec', 'categoryName')).not.toThrow();
+  });
+
+  it('rejects forward slashes', () => {
+    expect(() => PathUtils.validateSimplePathSegment('foo/bar', 'categoryName'))
+      .toThrow('categoryName must be a simple name without path traversal or directory separators');
+  });
+
+  it('rejects backslashes', () => {
+    expect(() => PathUtils.validateSimplePathSegment('foo\\bar', 'categoryName'))
+      .toThrow('categoryName must be a simple name without path traversal or directory separators');
+  });
+
+  it('rejects dot-dot traversal patterns', () => {
+    expect(() => PathUtils.validateSimplePathSegment('..foo', 'categoryName'))
+      .toThrow('categoryName must be a simple name without path traversal or directory separators');
+  });
+});
+
 describe('PathUtils root prefix edge case', () => {
   const originalEnv = { ...process.env };
 

--- a/src/core/path-utils.ts
+++ b/src/core/path-utils.ts
@@ -178,6 +178,27 @@ export class PathUtils {
   }
 
   /**
+   * Validate a single path segment that must not contain traversal or separators.
+   */
+  static validateSimplePathSegment(pathSegment: string, label: string = 'path segment'): void {
+    if (!pathSegment || typeof pathSegment !== 'string') {
+      throw new Error(`Invalid ${label}`);
+    }
+
+    if (
+      pathSegment === '.' ||
+      pathSegment.includes('..') ||
+      pathSegment.includes('/') ||
+      pathSegment.includes('\\') ||
+      pathSegment.includes('\0')
+    ) {
+      throw new Error(
+        `Security error: ${label} must be a simple name without path traversal or directory separators`
+      );
+    }
+  }
+
+  /**
    * Safely join paths ensuring no directory traversal
    */
   static safeJoin(basePath: string, ...paths: string[]): string {

--- a/src/dashboard/__tests__/approval-storage-path-resolution.test.ts
+++ b/src/dashboard/__tests__/approval-storage-path-resolution.test.ts
@@ -91,6 +91,30 @@ describe('ApprovalStorage path resolution', () => {
     ).rejects.toThrow('path traversal (..) is not allowed');
   });
 
+  it('rejects path traversal in categoryName', async () => {
+    await expect(
+      storage.createApproval('Review', 'test.md', 'spec', '../../../etc/passwd')
+    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+  });
+
+  it('rejects backslash path traversal in categoryName', async () => {
+    await expect(
+      storage.createApproval('Review', 'test.md', 'spec', '..\\..\\..\\outside')
+    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+  });
+
+  it('rejects absolute path in categoryName', async () => {
+    await expect(
+      storage.createApproval('Review', 'test.md', 'spec', '/etc/passwd')
+    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+  });
+
+  it('rejects nested directory separator in categoryName', async () => {
+    await expect(
+      storage.createApproval('Review', 'test.md', 'spec', 'foo/bar')
+    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+  });
+
   it('writes revisions to workspace file when it exists there', async () => {
     const relativePath = 'src/revision-target.ts';
     const workspaceFile = join(workspacePath, relativePath);

--- a/src/dashboard/__tests__/approval-storage-path-resolution.test.ts
+++ b/src/dashboard/__tests__/approval-storage-path-resolution.test.ts
@@ -94,25 +94,25 @@ describe('ApprovalStorage path resolution', () => {
   it('rejects path traversal in categoryName', async () => {
     await expect(
       storage.createApproval('Review', 'test.md', 'spec', '../../../etc/passwd')
-    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+    ).rejects.toThrow('categoryName must be a simple name without path traversal or directory separators');
   });
 
   it('rejects backslash path traversal in categoryName', async () => {
     await expect(
       storage.createApproval('Review', 'test.md', 'spec', '..\\..\\..\\outside')
-    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+    ).rejects.toThrow('categoryName must be a simple name without path traversal or directory separators');
   });
 
   it('rejects absolute path in categoryName', async () => {
     await expect(
       storage.createApproval('Review', 'test.md', 'spec', '/etc/passwd')
-    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+    ).rejects.toThrow('categoryName must be a simple name without path traversal or directory separators');
   });
 
   it('rejects nested directory separator in categoryName', async () => {
     await expect(
       storage.createApproval('Review', 'test.md', 'spec', 'foo/bar')
-    ).rejects.toThrow('categoryName must be a simple name without directory separators');
+    ).rejects.toThrow('categoryName must be a simple name without path traversal or directory separators');
   });
 
   it('writes revisions to workspace file when it exists there', async () => {

--- a/src/dashboard/approval-storage.ts
+++ b/src/dashboard/approval-storage.ts
@@ -272,10 +272,7 @@ export class ApprovalStorage extends EventEmitter {
       throw new Error('Security error: path traversal (..) is not allowed in filePath');
     }
 
-    // Security: validate categoryName is a single path segment
-    if (categoryName.includes('/') || categoryName.includes('\\')) {
-      throw new Error('Security error: categoryName must be a simple name without directory separators');
-    }
+    PathUtils.validateSimplePathSegment(categoryName, 'categoryName');
 
     const id = this.generateId();
     const approval: ApprovalRequest = {
@@ -329,6 +326,7 @@ export class ApprovalStorage extends EventEmitter {
         if (categoryName.isDirectory()) {
           let categoryPath: string;
           try {
+            PathUtils.validateSimplePathSegment(categoryName.name, 'categoryName');
             categoryPath = PathUtils.safeJoin(this.approvalsDir, categoryName.name);
           } catch {
             // Skip entries that fail path validation (e.g. malicious symlinks)
@@ -493,6 +491,7 @@ export class ApprovalStorage extends EventEmitter {
           if (categoryName.isDirectory()) {
             let categoryPath: string;
             try {
+              PathUtils.validateSimplePathSegment(categoryName.name, 'categoryName');
               categoryPath = PathUtils.safeJoin(this.approvalsDir, categoryName.name);
             } catch {
               // Skip entries that fail path validation (e.g. malicious symlinks)
@@ -596,7 +595,9 @@ export class ApprovalStorage extends EventEmitter {
     }
 
     // Create file-based snapshots directory
-    const categoryDir = PathUtils.safeJoin(this.approvalsDir, approval.categoryName || 'default');
+    const categoryName = approval.categoryName || 'default';
+    PathUtils.validateSimplePathSegment(categoryName, 'categoryName');
+    const categoryDir = PathUtils.safeJoin(this.approvalsDir, categoryName);
     const snapshotsDir = join(categoryDir, '.snapshots', basename(approval.filePath));
     await fs.mkdir(snapshotsDir, { recursive: true });
 
@@ -670,7 +671,9 @@ export class ApprovalStorage extends EventEmitter {
     if (!approval || !approval.filePath) return [];
 
     // Get snapshots based on file path, not approval ID
-    const categoryDir = PathUtils.safeJoin(this.approvalsDir, approval.categoryName || 'default');
+    const categoryName = approval.categoryName || 'default';
+    PathUtils.validateSimplePathSegment(categoryName, 'categoryName');
+    const categoryDir = PathUtils.safeJoin(this.approvalsDir, categoryName);
     const snapshotsDir = join(categoryDir, '.snapshots', basename(approval.filePath));
     const metadataPath = join(snapshotsDir, 'metadata.json');
 

--- a/src/dashboard/approval-storage.ts
+++ b/src/dashboard/approval-storage.ts
@@ -272,6 +272,11 @@ export class ApprovalStorage extends EventEmitter {
       throw new Error('Security error: path traversal (..) is not allowed in filePath');
     }
 
+    // Security: validate categoryName is a single path segment
+    if (categoryName.includes('/') || categoryName.includes('\\')) {
+      throw new Error('Security error: categoryName must be a simple name without directory separators');
+    }
+
     const id = this.generateId();
     const approval: ApprovalRequest = {
       id,
@@ -286,7 +291,7 @@ export class ApprovalStorage extends EventEmitter {
     };
 
     // Create category directory if it doesn't exist
-    const categoryDir = join(this.approvalsDir, categoryName);
+    const categoryDir = PathUtils.safeJoin(this.approvalsDir, categoryName);
     await fs.mkdir(categoryDir, { recursive: true });
 
     const approvalFilePath = join(categoryDir, `${id}.json`);
@@ -322,7 +327,14 @@ export class ApprovalStorage extends EventEmitter {
       const categoryNames = await fs.readdir(this.approvalsDir, { withFileTypes: true });
       for (const categoryName of categoryNames) {
         if (categoryName.isDirectory()) {
-          const approvalPath = join(this.approvalsDir, categoryName.name, `${id}.json`);
+          let categoryPath: string;
+          try {
+            categoryPath = PathUtils.safeJoin(this.approvalsDir, categoryName.name);
+          } catch {
+            // Skip entries that fail path validation (e.g. malicious symlinks)
+            continue;
+          }
+          const approvalPath = join(categoryPath, `${id}.json`);
           try {
             await fs.access(approvalPath);
             return approvalPath;
@@ -479,7 +491,13 @@ export class ApprovalStorage extends EventEmitter {
         const categoryNames = await fs.readdir(this.approvalsDir, { withFileTypes: true });
         for (const categoryName of categoryNames) {
           if (categoryName.isDirectory()) {
-            const categoryPath = join(this.approvalsDir, categoryName.name);
+            let categoryPath: string;
+            try {
+              categoryPath = PathUtils.safeJoin(this.approvalsDir, categoryName.name);
+            } catch {
+              // Skip entries that fail path validation (e.g. malicious symlinks)
+              continue;
+            }
             try {
               const approvalFiles = await fs.readdir(categoryPath);
               for (const file of approvalFiles) {
@@ -578,7 +596,7 @@ export class ApprovalStorage extends EventEmitter {
     }
 
     // Create file-based snapshots directory
-    const categoryDir = join(this.approvalsDir, approval.categoryName || 'default');
+    const categoryDir = PathUtils.safeJoin(this.approvalsDir, approval.categoryName || 'default');
     const snapshotsDir = join(categoryDir, '.snapshots', basename(approval.filePath));
     await fs.mkdir(snapshotsDir, { recursive: true });
 
@@ -652,7 +670,7 @@ export class ApprovalStorage extends EventEmitter {
     if (!approval || !approval.filePath) return [];
 
     // Get snapshots based on file path, not approval ID
-    const categoryDir = join(this.approvalsDir, approval.categoryName || 'default');
+    const categoryDir = PathUtils.safeJoin(this.approvalsDir, approval.categoryName || 'default');
     const snapshotsDir = join(categoryDir, '.snapshots', basename(approval.filePath));
     const metadataPath = join(snapshotsDir, 'metadata.json');
 

--- a/src/tools/__tests__/projectPath.test.ts
+++ b/src/tools/__tests__/projectPath.test.ts
@@ -149,6 +149,30 @@ describe('Tool projectPath fallback behavior', () => {
       expect(result.message).toContain('Project path is required but not provided');
     });
 
+    it('should reject malicious categoryName in request action', async () => {
+      const tempProject = await createTempProject('specwf-cat-trav-');
+
+      try {
+        const result = await approvalsHandler(
+          {
+            action: 'request',
+            title: 'Test approval',
+            filePath: 'test.txt',
+            type: 'document',
+            category: 'spec',
+            categoryName: '..\\..\\..\\outside'
+          },
+          { projectPath: tempProject }
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('Security error');
+        expect(result.message).toContain('categoryName');
+      } finally {
+        await rm(tempProject, { recursive: true, force: true });
+      }
+    });
+
     it('should not report PathUtils.translatePath error for request action', async () => {
       const result = await approvalsHandler(
         {
@@ -161,7 +185,7 @@ describe('Tool projectPath fallback behavior', () => {
         },
         mockContext
       );
-      
+
       // The actual error should be about path validation, not about PathUtils
       expect(result.success).toBe(false);
       expect(result.message).not.toContain('PathUtils.translatePath is not a function');

--- a/src/tools/approvals.ts
+++ b/src/tools/approvals.ts
@@ -233,12 +233,16 @@ async function handleRequestApproval(
       };
     }
 
-    // Security: Validate categoryName to prevent path traversal in approval directory names
-    if (args.categoryName.includes('..') || args.categoryName.includes('/') || args.categoryName.includes('\\')) {
+    // Security: validate categoryName at the tool boundary before storage access
+    try {
+      PathUtils.validateSimplePathSegment(args.categoryName, 'categoryName');
+    } catch (error) {
       await approvalStorage.stop();
       return {
         success: false,
-        message: 'Security error: categoryName must be a simple name without path traversal or directory separators.'
+        message: error instanceof Error
+          ? error.message
+          : 'Security error: categoryName must be a simple name without path traversal or directory separators.'
       };
     }
 

--- a/src/tools/approvals.ts
+++ b/src/tools/approvals.ts
@@ -233,6 +233,15 @@ async function handleRequestApproval(
       };
     }
 
+    // Security: Validate categoryName to prevent path traversal in approval directory names
+    if (args.categoryName.includes('..') || args.categoryName.includes('/') || args.categoryName.includes('\\')) {
+      await approvalStorage.stop();
+      return {
+        success: false,
+        message: 'Security error: categoryName must be a simple name without path traversal or directory separators.'
+      };
+    }
+
     const isMarkdownFile = args.filePath.toLowerCase().endsWith('.md');
     let markdownContent: string | undefined;
 


### PR DESCRIPTION
## Summary
- Fixes issue #220 where a malicious `categoryName` value (e.g. `..\\..\\..\\outside`) could write approval JSON files outside the intended `.spec-workflow/approvals` directory.
- Adds defense-in-depth validation at both the MCP tool handler and the `ApprovalStorage` layer.
- Replaces all raw `join(this.approvalsDir, categoryName)` calls with `PathUtils.safeJoin()` to enforce path containment.
- Adds unit tests for categoryName traversal rejection in both the tool handler and storage layer.

## Test plan
- [x] `npm test` passes (191 tests)
- [x] New unit tests verify `createApproval` rejects `..`, `/`, and `\\` in `categoryName`
- [x] New unit test verifies `approvalsHandler` returns `success: false` with a security message for malicious `categoryName`
- [x] No files are written outside the project during the rejection tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)