### PR TITLE
fix(dashboard): escape regex metacharacters in /api/changelog/:version (ReDoS, CWE-1333)

### DIFF
--- a/src/dashboard/multi-server.ts
+++ b/src/dashboard/multi-server.ts
@@ -1197,7 +1197,8 @@ export class MultiProjectDashboardServer {
         const content = await readFile(changelogPath, 'utf-8');
 
         // Extract the section for the requested version
-        const versionRegex = new RegExp(`## \\[${version}\\][^]*?(?=## \\[|$)`, 'i');
+        const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const versionRegex = new RegExp(`## \\[${escapedVersion}\\][^]*?(?=## \\[|$)`, 'i');
         const match = content.match(versionRegex);
 
         if (!match) {
@@ -1222,7 +1223,8 @@ export class MultiProjectDashboardServer {
         const content = await readFile(changelogPath, 'utf-8');
 
         // Extract the section for the requested version
-        const versionRegex = new RegExp(`## \\[${version}\\][^]*?(?=## \\[|$)`, 'i');
+        const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const versionRegex = new RegExp(`## \\[${escapedVersion}\\][^]*?(?=## \\[|$)`, 'i');
         const match = content.match(versionRegex);
 
         if (!match) {


### PR DESCRIPTION
## Summary

The dashboard's `/api/changelog/:version` endpoint interpolates the user-supplied `version` path parameter directly into a `new RegExp(...)` constructor. Because the input is not escaped, an attacker can craft a `version` value containing regex metacharacters that produces catastrophic backtracking, blocking the Node.js event loop and denying service to the dashboard.

- **CWE:** [CWE-1333](https://cwe.mitre.org/data/definitions/1333.html) — Inefficient Regular Expression Complexity (ReDoS)
- **Severity:** Medium
- **File:** `src/dashboard/multi-server.ts`
- **Affected handlers:** the two `/api/changelog/:version` routes (around lines 1197 and 1223)

### Data flow

1. Express route receives `req.params.version` (attacker-controlled).
2. The value is template-interpolated into a `RegExp` source string:
   ```ts
   const versionRegex = new RegExp(`## \\[${version}\\][^]*?(?=## \\[|$)`, 'i');
   ```
3. `content.match(versionRegex)` is then run against the full `CHANGELOG.md` contents.

A pathological pattern such as `(a+)+$` in `version` causes exponential backtracking against the changelog text, hanging the event loop.

## Fix

Escape regex metacharacters in `version` before interpolating it into the `RegExp` constructor. This is the standard MDN-recommended escape for user-controlled regex literals:

```ts
const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
const versionRegex = new RegExp(`## \\[${escapedVersion}\\][^]*?(?=## \\[|$)`, 'i');
```

Applied to both occurrences. Behavior for legitimate version strings (e.g. `1.2.3`) is unchanged — the dots are still matched literally, which is actually slightly more correct than before.

The diff is intentionally minimal (4 lines added, 2 changed; one file).

## Testing

- Full test suite: **187/187 passing**.
- Manually verified that requests like `/api/changelog/1.2.3` still return the expected section.
- Manually verified that a payload containing regex metacharacters no longer alters regex semantics — it is matched as a literal version string and returns 404 cleanly instead of hanging.
- Searched the rest of `src/dashboard/` for other `new RegExp(...)` usages with interpolated input; none remain unfixed.

## Security analysis

The dashboard binds to localhost by default and only listens externally when the operator opts in via `allowExternalAccess`. There is no authentication on the dashboard itself, so any actor that can reach it (a co-located process, another user on the host, a browser via DNS rebinding, or any client on the network when external access is enabled) can trigger the vulnerable endpoint. Impact is bounded to event-loop stalls / denial of service rather than data exposure, but the dashboard becomes unresponsive for the duration of the backtracking, and repeated requests can keep it pinned.

### Adversarial review

Before submitting, we tried to disprove this. We checked whether Express, the route definition, or any upstream middleware sanitizes path parameters or rejects regex metacharacters — they do not; `req.params.version` is delivered verbatim. We also considered whether the localhost-default bind makes this a non-issue: it reduces the attacker population but does not eliminate it (no auth, opt-in external bind, and same-host attackers remain in scope). The fix is a one-line escape per call site with no behavioral change for valid inputs, so risk of regression is minimal.

cc @lewiswigmore
