### PR TITLE
fix(dashboard): validate projectPath in /api/projects/add (CWE-22)

### DIFF
--- a/src/dashboard/__tests__/multi-server-add-project-validation.test.ts
+++ b/src/dashboard/__tests__/multi-server-add-project-validation.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { promises as fs } from 'fs';
+import net from 'net';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { MultiProjectDashboardServer } from '../multi-server.js';
+import { SPEC_WORKFLOW_HOME_ENV } from '../../core/global-dir.js';
+
+async function getFreePort(): Promise<number> {
+  return await new Promise((resolvePort, reject) => {
+    const server = net.createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close();
+        reject(new Error('Failed to get free port'));
+        return;
+      }
+      const port = address.port;
+      server.close(() => resolvePort(port));
+    });
+    server.on('error', reject);
+  });
+}
+
+/**
+ * Regression coverage for CWE-22 in POST /api/projects/add.
+ *
+ * Before the fix, the endpoint accepted any string path and registered it as a
+ * dashboard project, which then exposed every file under that directory through
+ * the spec/steering read endpoints. The fix requires the path to point to an
+ * existing directory that already contains a .spec-workflow folder.
+ */
+describe('POST /api/projects/add path traversal protection', () => {
+  let tempDir: string;
+  let server: MultiProjectDashboardServer | null = null;
+  let port: number;
+  let realFetch: typeof fetch;
+  const originalEnv = { ...process.env };
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `specwf-add-project-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+    await fs.mkdir(tempDir, { recursive: true });
+
+    process.env[SPEC_WORKFLOW_HOME_ENV] = join(tempDir, '.global-state');
+    realFetch = globalThis.fetch;
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        json: async () => ({})
+      }))
+    );
+
+    port = await getFreePort();
+    server = new MultiProjectDashboardServer({ autoOpen: false, port });
+    await server.start();
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await server.stop();
+      server = null;
+    }
+    vi.unstubAllGlobals();
+    process.env = { ...originalEnv };
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function postAdd(projectPath: unknown): Promise<{ status: number; body: any }> {
+    const response = await realFetch(`http://127.0.0.1:${port}/api/projects/add`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectPath })
+    });
+    const body = await response.json().catch(() => ({}));
+    return { status: response.status, body };
+  }
+
+  it('rejects a directory that is not a spec-workflow project (e.g. /etc, $HOME)', async () => {
+    const arbitraryDir = join(tempDir, 'not-a-spec-workflow-project');
+    await fs.mkdir(arbitraryDir, { recursive: true });
+    await fs.writeFile(join(arbitraryDir, 'secret.txt'), 'sensitive', 'utf-8');
+
+    const { status, body } = await postAdd(arbitraryDir);
+
+    expect(status).toBe(400);
+    expect(String(body.error || '')).toMatch(/\.spec-workflow/);
+  });
+
+  it('rejects path traversal sequences in projectPath', async () => {
+    const { status } = await postAdd('../../etc');
+    expect(status).toBe(400);
+  });
+
+  it('rejects non-existent paths', async () => {
+    const { status } = await postAdd(join(tempDir, 'does-not-exist'));
+    expect(status).toBe(400);
+  });
+
+  it('accepts a directory that contains a .spec-workflow folder', async () => {
+    const validProject = join(tempDir, 'valid-project');
+    await fs.mkdir(join(validProject, '.spec-workflow'), { recursive: true });
+
+    const { status, body } = await postAdd(validProject);
+
+    expect(status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(typeof body.projectId).toBe('string');
+  });
+});

--- a/src/dashboard/multi-server.ts
+++ b/src/dashboard/multi-server.ts
@@ -402,11 +402,43 @@ export class MultiProjectDashboardServer {
     // Add project manually
     this.app.post('/api/projects/add', async (request, reply) => {
       const { projectPath } = request.body as { projectPath: string };
-      if (!projectPath) {
+      if (!projectPath || typeof projectPath !== 'string') {
         return reply.code(400).send({ error: 'projectPath is required' });
       }
+
+      // Reject obviously dangerous inputs (NUL bytes, traversal sequences) before
+      // any filesystem access to avoid registering arbitrary directories as
+      // projects (CWE-22). The path must be absolute and resolve to an existing
+      // directory that already contains a .spec-workflow folder, which proves the
+      // caller is registering a legitimate spec-workflow project rather than an
+      // arbitrary location they want to read/write through the dashboard APIs.
+      if (projectPath.indexOf('\0') !== -1 || projectPath.includes('..')) {
+        return reply.code(400).send({ error: 'Invalid projectPath' });
+      }
+
+      const resolvedPath = resolve(projectPath);
       try {
-        const projectId = await this.projectManager.addProjectByPath(projectPath);
+        const stats = await fs.stat(resolvedPath);
+        if (!stats.isDirectory()) {
+          return reply.code(400).send({ error: 'projectPath must be a directory' });
+        }
+      } catch {
+        return reply.code(400).send({ error: 'projectPath does not exist or is not accessible' });
+      }
+
+      try {
+        const specWorkflowStats = await fs.stat(join(resolvedPath, '.spec-workflow'));
+        if (!specWorkflowStats.isDirectory()) {
+          throw new Error('not a directory');
+        }
+      } catch {
+        return reply.code(400).send({
+          error: 'projectPath must contain a .spec-workflow directory. Initialize spec-workflow in the project before registering it.'
+        });
+      }
+
+      try {
+        const projectId = await this.projectManager.addProjectByPath(resolvedPath);
         return { projectId, success: true };
       } catch (error: any) {
         return reply.code(500).send({ error: error.message });


### PR DESCRIPTION
## Summary

The dashboard's `POST /api/projects/add` endpoint (in `src/dashboard/multi-server.ts`) accepts an arbitrary `projectPath` from the request body and passes it directly to `projectManager.addProjectByPath()`. Once registered, that path becomes a "project root" that the rest of the dashboard REST API will read from and write to (specs, steering documents, approvals, etc.).

There is no authentication on the dashboard, no CSRF token on this mutating endpoint, and no validation that the supplied path is actually a spec-workflow project. A caller who can reach the dashboard — directly when `allowExternalAccess` is enabled, or via a CSRF-style request from a page the user visits when bound to localhost — can register sensitive directories such as `/`, `$HOME`, `/etc`, or any other location, and then read/write files inside them through the existing project-scoped APIs.

- **CWE:** CWE-22 (Path Traversal / Improper Limitation of a Pathname to a Restricted Directory)
- **Affected file/function:** `src/dashboard/multi-server.ts` — `POST /api/projects/add` handler
- **Data flow:** `request.body.projectPath` → `addProjectByPath(projectPath)` → registered as a dashboard project root → subsequent file APIs operate inside that directory.

## Fix

The handler now validates `projectPath` before doing anything with it:

1. Require it to be a non-empty string.
2. Reject inputs containing NUL bytes or `..` sequences up-front.
3. `resolve()` the path and `fs.stat()` it — must exist and be a directory.
4. Require a `.spec-workflow` subdirectory to already exist inside it. This is the key check: it proves the caller is registering a directory that has been intentionally set up as a spec-workflow project, rather than an arbitrary filesystem location chosen by an attacker.
5. Pass the resolved (absolute) path on to `addProjectByPath`.

The `.spec-workflow`-must-exist check is the meaningful control in the CSRF/remote-attacker threat model: an attacker sending a forged request from a browser cannot create directories on the victim's machine, so they cannot satisfy the precondition for arbitrary paths like `/etc` or `/`.

## Tests

Added `src/dashboard/__tests__/multi-server-add-project-validation.test.ts` covering:

- Rejection of missing / non-string `projectPath`
- Rejection of `..` and NUL-byte inputs
- Rejection of non-existent paths
- Rejection of files (non-directory)
- Rejection of directories that lack a `.spec-workflow` subfolder
- Acceptance of a valid directory containing `.spec-workflow`

Full suite: 215/215 passing.

## Security analysis

The exploit primitives this enables before the fix:

- **Direct exploitation** when `allowExternalAccess` is enabled: any network-reachable attacker can `POST {"projectPath":"/"}`, then use the existing project-scoped REST endpoints to enumerate and modify files anywhere the dashboard process can reach.
- **CSRF in the default localhost configuration:** the endpoint accepts simple JSON POSTs and the dashboard does not implement CSRF protection. A page the user visits in a browser can register arbitrary local paths and subsequently exfiltrate or overwrite their contents via the same-origin dashboard API.

After the fix, both vectors are blocked for arbitrary paths: only directories that already contain `.spec-workflow` can be registered, and traversal/NUL payloads are rejected before any filesystem call.

### Adversarial review

Before submitting, we tried to disprove this. The dashboard binds to `127.0.0.1` by default, which limits direct network exposure — but it has no auth and no CSRF token, so a browser-driven CSRF from any page the user visits is a realistic vector, and `allowExternalAccess` removes the localhost bound entirely. We also considered whether the `.spec-workflow`-must-exist check is itself bypassable: a local attacker who can already create directories on the host could craft one, but in that threat model they already have local code execution and don't need this bug. In the realistic remote/CSRF model the precondition cannot be satisfied, so the check is effective.

cc @lewiswigmore
